### PR TITLE
Fix timestamp/date querying with improved heuristic for all data source types

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,42 @@
+# Lark Base Test Setup - Environment Variables Template
+# Copy this file to .env and fill in your values
+
+# ============================================================================
+# Lark Configuration (Required)
+# ============================================================================
+# Get these from: https://open.larksuite.com/app
+LARK_APP_ID=your_lark_app_id
+LARK_APP_SECRET=your_lark_app_secret
+
+# Optional: Folder token to create test base in
+# Get from Lark Drive URL: https://drive.larksuite.com/folder/{FOLDER_TOKEN}
+LARK_FOLDER_TOKEN=
+
+# ============================================================================
+# AWS Configuration
+# ============================================================================
+# AWS region for deployment
+AWS_REGION=ap-southeast-1
+
+# Glue Crawler Lambda function name
+GLUE_CRAWLER_LAMBDA_NAME=lark-base-glue-crawler
+
+# S3 bucket for Athena query results
+OUTPUT_LOCATION=s3://your-athena-results-bucket/regression-tests/
+
+# Athena workgroup (optional, defaults to 'primary')
+ATHENA_WORKGROUP=poweruser
+
+# ============================================================================
+# Test Configuration (Populated by setup-lark-test-data.py)
+# ============================================================================
+# These will be set after running the setup script
+LARK_BASE_APP_TOKEN=
+LARK_BASE_TABLE_ID=
+LARK_BASE_TABLE_NAME=data_type_test_table
+
+# ============================================================================
+# Test Database Configuration
+# ============================================================================
+TEST_DATABASE=athena_lark_base_regression_test
+TEST_TABLE=data_type_test_table

--- a/REGRESSION_TESTING_GUIDE.md
+++ b/REGRESSION_TESTING_GUIDE.md
@@ -1,0 +1,603 @@
+# Athena-Lark-Base Connector - Regression Testing Guide
+
+**Last Updated**: 2025-10-04
+**Purpose**: Comprehensive guide for regression testing all Lark Base data types with Athena Query Federation
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Testing Workflow](#testing-workflow)
+3. [Test Environment Setup](#test-environment-setup)
+4. [Supported Data Types](#supported-data-types)
+5. [Test Coverage Matrix](#test-coverage-matrix)
+6. [Running Tests](#running-tests)
+7. [Known Edge Cases](#known-edge-cases)
+8. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+This connector bridges AWS Athena with Lark Base (Feishu/飞书多维表格), enabling SQL queries over Lark's spreadsheet-like data. The regression test suite validates:
+
+- ✅ All 26 supported Lark data types
+- ✅ Type mapping accuracy (Lark → Arrow → Athena)
+- ✅ Filter pushdown for primitive types
+- ✅ Sort and LIMIT optimization
+- ✅ Complex nested structures (LIST, STRUCT)
+- ✅ NULL handling and edge cases
+- ✅ Reserved system fields
+
+**Test Script**: `regression-test-plan.sh` (51 test cases)
+
+---
+
+## Testing Workflow
+
+### Workflow for Code Changes
+
+When making any code changes to the connector, follow this workflow:
+
+```
+1. Make Code Changes
+   ↓
+2. Run Unit Tests (make test)
+   ↓
+3. If Tests Pass → Deploy to AWS (if needed)
+   ↓
+4. Ask Permission from User
+   ↓
+5. Run Regression Tests (regression-test-plan.sh)
+   ↓
+6. Validate Results
+   ↓
+7. Report Findings
+```
+
+### Sub-Agent Instructions
+
+**Alternative invocation**:
+
+If you are a sub-agent working on this codebase and the terminal has restarted:
+
+1. **Read this document** to understand the testing approach
+2. **Check the latest changes** in git history
+3. **Run unit tests** after any code modification:
+   ```bash
+   make test
+   ```
+4. **For AWS-testable changes**, ask the user for permission before running:
+   ```bash
+   ./regression-test-plan.sh
+   ```
+5. **Never run AWS tests** without explicit user approval (costs money!)
+
+---
+
+## Test Environment Setup
+
+### Step 1: Create Test Lark Base
+
+Create a Lark Base (多维表格) with the following structure:
+
+**Database Name**: `lark_base_test`
+**Table Name**: `data_type_test_table`
+
+#### Required Fields (All 26 Types):
+
+| Field Name | Lark Type | Athena Type | Sample Data |
+|-----------|-----------|-------------|-------------|
+| `field_text` | TEXT | string | "Sample text", "Test 123", "" |
+| `field_barcode` | BARCODE | string | "1234567890", "ABC-123" |
+| `field_single_select` | SINGLE_SELECT | string | "Option A", "Option B", null |
+| `field_phone` | PHONE | string | "+1-555-1234", "555-5678" |
+| `field_email` | EMAIL | string | "test@example.com", null |
+| `field_auto_number` | AUTO_NUMBER | string | "AUTO-001", "AUTO-002" |
+| `field_number` | NUMBER | decimal(38,18) | 123.456, -789.012, 0 |
+| `field_progress` | PROGRESS | decimal(38,18) | 0.5, 0.75, 1.0 |
+| `field_currency` | CURRENCY | decimal(38,18) | 1000.50, 2500.75 |
+| `field_rating` | RATING | tinyint | 1, 3, 5 |
+| `field_checkbox` | CHECKBOX | boolean | true, false, null |
+| `field_date_time` | DATE_TIME | timestamp | 2024-01-01 12:00:00 |
+| `field_created_time` | CREATED_TIME | timestamp | Auto-generated |
+| `field_modified_time` | MODIFIED_TIME | timestamp | Auto-generated |
+| `field_multi_select` | MULTI_SELECT | array\<string\> | ["Tag1", "Tag2"], [] |
+| `field_user` | USER | array\<struct\> | [{"id": "u1", "name": "Alice"}] |
+| `field_group_chat` | GROUP_CHAT | array\<struct\> | [{"id": "g1", "name": "Team"}] |
+| `field_attachment` | ATTACHMENT | array\<struct\> | [{"name": "file.pdf", "size": 1024}] |
+| `field_single_link` | SINGLE_LINK | array\<struct\> | [{"record_ids": ["r1"], "text": "Link"}] |
+| `field_duplex_link` | DUPLEX_LINK | array\<struct\> | [{"record_ids": ["r2"], "text": "BiLink"}] |
+| `field_url` | URL | struct | {"link": "https://...", "text": "Label"} |
+| `field_location` | LOCATION | struct | {"address": "123 Main St", "full_address": "..."} |
+| `field_created_user` | CREATED_USER | struct | {"id": "u1", "name": "Alice", "email": "..."} |
+| `field_modified_user` | MODIFIED_USER | struct | {"id": "u2", "name": "Bob", "email": "..."} |
+| `field_formula` | FORMULA | varies | CONCATENATE({field_text}, " - ", {field_number}) |
+| `field_lookup` | LOOKUP | varies | Lookup to another table's field |
+
+#### Sample Data Requirements:
+
+Create **at least 10 rows** with the following edge cases:
+
+1. **Row 1**: All fields populated with typical values
+2. **Row 2**: All fields NULL/empty where possible
+3. **Row 3**: Maximum length strings (test boundaries)
+4. **Row 4**: Numeric edge cases (0, negative, very large numbers)
+5. **Row 5**: Past dates (before 2000)
+6. **Row 6**: Future dates (after 2030)
+7. **Row 7**: Empty arrays for all list types
+8. **Row 8**: Arrays with single elements
+9. **Row 9**: Arrays with multiple elements (3+)
+10. **Row 10**: Complex formula and lookup scenarios
+
+### Step 2: Deploy AWS Infrastructure
+
+#### 2.1 Build and Package the Connector
+
+```bash
+# Build the project
+make build
+
+# Package for Lambda deployment
+mvn clean package shade:shade
+```
+
+#### 2.2 Create Lambda Function
+
+```bash
+aws lambda create-function \
+  --function-name athena-lark-base-connector \
+  --runtime java11 \
+  --role arn:aws:iam::ACCOUNT_ID:role/lambda-athena-execution-role \
+  --handler com.amazonaws.athena.connectors.lark.base.BaseCompositeHandler \
+  --code S3Bucket=your-bucket,S3Key=athena-lark-base-connector.jar \
+  --timeout 900 \
+  --memory-size 3008 \
+  --environment Variables="{
+    SPILL_BUCKET=your-spill-bucket,
+    LARK_APP_ID=your_app_id,
+    LARK_APP_SECRET=your_app_secret
+  }"
+```
+
+#### 2.3 Register Athena Data Catalog
+
+```bash
+aws athena create-data-catalog \
+  --name lark_base_catalog \
+  --type LAMBDA \
+  --parameters "function=arn:aws:lambda:REGION:ACCOUNT:function:athena-lark-base-connector"
+```
+
+#### 2.4 Run Glue Crawler (Optional but Recommended)
+
+If using Glue integration for metadata:
+
+```bash
+# Deploy the Glue crawler Lambda
+# (see glue-lark-base-crawler module)
+
+# Run crawler to populate catalog
+aws lambda invoke \
+  --function-name lark-base-glue-crawler \
+  --payload '{"databases": ["lark_base_test"]}' \
+  response.json
+```
+
+### Step 3: Configure Environment Variables
+
+```bash
+export TEST_DATABASE="lark_base_test"
+export TEST_TABLE="data_type_test_table"
+export OUTPUT_LOCATION="s3://your-athena-results-bucket/regression-tests/"
+export AWS_REGION="us-east-1"
+export ATHENA_WORKGROUP="primary"
+```
+
+### Step 4: Verify Setup
+
+```bash
+# Test connectivity
+aws athena start-query-execution \
+  --query-string "SHOW DATABASES IN lark_base_catalog" \
+  --result-configuration "OutputLocation=$OUTPUT_LOCATION"
+
+# Check table schema
+aws athena start-query-execution \
+  --query-string "DESCRIBE lark_base_catalog.$TEST_DATABASE.$TEST_TABLE" \
+  --result-configuration "OutputLocation=$OUTPUT_LOCATION"
+```
+
+---
+
+## Supported Data Types
+
+### Type Mapping Reference
+
+| Lark Type | Arrow Type | SQL Type | Filter Pushdown | Notes |
+|-----------|-----------|----------|-----------------|-------|
+| TEXT | VARCHAR | string | ✅ Yes | Simple string |
+| BARCODE | VARCHAR | string | ✅ Yes | String representation |
+| SINGLE_SELECT | VARCHAR | string | ✅ Yes | Selected option |
+| PHONE | VARCHAR | string | ✅ Yes | Phone number |
+| EMAIL | VARCHAR | string | ✅ Yes | Email address |
+| AUTO_NUMBER | VARCHAR | string | ❌ No | Auto-generated ID |
+| NUMBER | DECIMAL(38,18) | decimal | ✅ Yes | High precision |
+| PROGRESS | DECIMAL(38,18) | decimal | ✅ Yes | 0.0 - 1.0 |
+| CURRENCY | DECIMAL(38,18) | decimal | ✅ Yes | Currency amount |
+| RATING | TINYINT | tinyint | ✅ Yes | 0-5 stars |
+| CHECKBOX | BIT | boolean | ✅ Yes | true/false |
+| DATE_TIME | DATEMILLI | timestamp | ❌ No | Milliseconds epoch |
+| CREATED_TIME | DATEMILLI | timestamp | ❌ No | Auto-populated |
+| MODIFIED_TIME | DATEMILLI | timestamp | ❌ No | Auto-populated |
+| MULTI_SELECT | LIST<VARCHAR> | array\<string\> | ❌ No | Array of options |
+| USER | LIST<STRUCT> | array\<struct\> | ❌ No | id, name, email, en_name |
+| GROUP_CHAT | LIST<STRUCT> | array\<struct\> | ❌ No | id, name, avatar_url |
+| ATTACHMENT | LIST<STRUCT> | array\<struct\> | ❌ No | name, size, url, type, file_token, tmp_url |
+| SINGLE_LINK | LIST<STRUCT> | array\<struct\> | ❌ No | record_ids, table_id, text, text_arr, type |
+| DUPLEX_LINK | LIST<STRUCT> | array\<struct\> | ❌ No | Same as SINGLE_LINK |
+| URL | STRUCT | struct | ❌ No | link, text |
+| LOCATION | STRUCT | struct | ❌ No | address, adname, cityname, full_address, location, name, pname |
+| CREATED_USER | STRUCT | struct | ❌ No | id, name, en_name, email |
+| MODIFIED_USER | STRUCT | struct | ❌ No | id, name, en_name, email |
+| FORMULA | Varies | varies | ❌ No | Depends on formula result type |
+| LOOKUP | Varies | varies | ❌ No | Recursively resolved |
+
+### Special Behaviors
+
+#### CHECKBOX Null Handling
+- `WHERE checkbox IS NULL` → Translated to `checkbox = false` in FQL
+- `WHERE checkbox IS NOT NULL` → Translated to `checkbox = true` in FQL
+- Rationale: Lark treats unchecked as false, not NULL
+
+#### Date Type Detection (Heuristic)
+```java
+// Excel epoch: 1899-12-30 (with 2-day adjustment for 1900 leap year bug)
+// Threshold: 2 billion (approx year 2033 in milliseconds)
+if (numericValue < 2_000_000_000) {
+    // Treat as Excel days
+    daysSinceExcelEpoch = numericValue;
+    millisSinceUnixEpoch = (daysSinceExcelEpoch - 25567) * 86400000;
+} else {
+    // Treat as Unix timestamp milliseconds
+    millisSinceUnixEpoch = numericValue;
+}
+```
+
+**Edge Case**: Dates between 1970-01-24 and 2033-05-18 might be ambiguous!
+
+#### FORMULA and LOOKUP Resolution
+- FORMULA fields have a `childType` indicating result type
+- LOOKUP fields recursively resolve via API call to target table
+- Special handling for TEXT formulas: extracts `{text: "..."}` format
+
+---
+
+## Test Coverage Matrix
+
+### Test Categories (51 Tests)
+
+| Category | Tests | Description |
+|----------|-------|-------------|
+| **1. Basic Data Types** | 5 | TEXT, BARCODE, SINGLE_SELECT, PHONE, EMAIL |
+| **2. Numeric Types** | 5 | NUMBER, PROGRESS, CURRENCY, RATING, aggregations |
+| **3. Boolean & Dates** | 5 | CHECKBOX, DATE_TIME, CREATED_TIME, MODIFIED_TIME, formatting |
+| **4. Array Types** | 5 | MULTI_SELECT, USER, GROUP_CHAT, ATTACHMENT, cardinality |
+| **5. Struct Types** | 5 | URL, LOCATION, CREATED_USER, nested field access |
+| **6. Complex Types** | 4 | FORMULA, LOOKUP, SINGLE_LINK, DUPLEX_LINK |
+| **7. Filter Pushdown** | 7 | =, >, <, !=, IN, IS NULL, combined filters |
+| **8. Sort & Limit** | 3 | ORDER BY, LIMIT, Top-N optimization |
+| **9. NULL Handling** | 4 | IS NULL, IS NOT NULL, COALESCE |
+| **10. Edge Cases** | 5 | Empty arrays, pagination, nested access, reserved fields |
+| **11. Type Conversions** | 3 | CAST operations |
+
+### Filter Pushdown Support
+
+**Supported (9 types)**:
+- TEXT, BARCODE, SINGLE_SELECT, PHONE, EMAIL
+- NUMBER, PROGRESS, CURRENCY, RATING
+- CHECKBOX
+
+**Operators**:
+- `=`, `!=`, `>`, `>=`, `<`, `<=`
+- `IN (...)`, `NOT IN (...)`
+- `IS NULL`, `IS NOT NULL`
+- `BETWEEN ... AND ...`
+
+**FQL Translation Examples**:
+
+```sql
+-- SQL
+WHERE status = 'active'
+-- FQL
+CurrentValue.[status]="active"
+
+-- SQL
+WHERE age > 18 AND age <= 65
+-- FQL
+AND(CurrentValue.[age]>18,CurrentValue.[age]<=65)
+
+-- SQL
+WHERE status IN ('active', 'pending')
+-- FQL
+OR(CurrentValue.[status]="active",CurrentValue.[status]="pending")
+
+-- SQL
+WHERE checkbox IS TRUE
+-- FQL
+CurrentValue.[checkbox]=1
+
+-- SQL
+WHERE checkbox IS NULL
+-- FQL (special handling)
+CurrentValue.[checkbox]=false
+```
+
+---
+
+## Running Tests
+
+### Show Setup Instructions
+
+```bash
+./regression-test-plan.sh --setup
+```
+
+### Run Full Test Suite
+
+```bash
+./regression-test-plan.sh
+```
+
+### Run with Custom Configuration
+
+```bash
+TEST_DATABASE=my_custom_db \
+TEST_TABLE=my_table \
+OUTPUT_LOCATION=s3://my-bucket/results/ \
+./regression-test-plan.sh
+```
+
+### Expected Output
+
+```
+================================================================================
+  Athena-Lark-Base Connector - Regression Test Suite
+================================================================================
+
+Configuration:
+  Database: lark_base_test
+  Table: data_type_test_table
+  Workgroup: primary
+  Region: us-east-1
+  Output Location: s3://your-bucket/
+
+================================================================================
+
+[INFO] Running pre-flight checks...
+[PASS] Pre-flight checks completed
+[INFO] ==== Testing Basic Data Types ====
+[INFO] Executing: Read TEXT field
+[PASS] Read TEXT field
+[INFO] Executing: Read BARCODE field
+[PASS] Read BARCODE field
+...
+================================================================================
+  Test Summary
+================================================================================
+  Total Tests: 51
+  Passed: 48
+  Failed: 3
+  Skipped: 0
+  Duration: 245s
+================================================================================
+```
+
+---
+
+## Known Edge Cases
+
+### 1. Date Type Ambiguity
+**Issue**: Dates between 1970-01-24 and 2033-05-18 might be misinterpreted
+**Detection**: Numeric values < 2 billion treated as Excel epoch days
+**Workaround**: Use explicit date formatting in Lark
+**Files**: `RegistererExtractor.java:324-355`
+
+### 2. Checkbox NULL Semantics
+**Issue**: `IS NULL` maps to `= false`, not actual NULL
+**Reason**: Lark doesn't distinguish unchecked from NULL
+**Impact**: Can't detect truly missing checkbox values
+**Files**: `ConstraintTranslator.java:157-163`
+
+### 3. FORMULA TEXT Extraction
+**Issue**: TEXT formulas return `[{text: "..."}]` format
+**Handling**: Special case to extract first element's text field
+**Edge Case**: Multi-value formula results might be truncated
+**Files**: `RegistererExtractor.java:244-260`
+
+### 4. LOOKUP Chains
+**Issue**: Deep lookup chains require multiple API calls
+**Impact**: Slow schema discovery for complex lookups
+**Limitation**: No circular reference detection
+**Files**: `LarkBaseService.java:getLookupType()`
+
+### 5. Empty String vs NULL
+**Issue**: VARCHAR fields use `""` for NULL in filters
+**Behavior**: `IS NOT NULL` adds `NOT(field="")` check
+**Edge Case**: Explicit empty strings treated as NULL
+**Files**: `ConstraintTranslator.java:244-260`
+
+### 6. Date Filter Not Pushed Down
+**Issue**: DATE_TIME, CREATED_TIME, MODIFIED_TIME filters not in pushdown whitelist
+**Impact**: All date filtering happens in Athena after fetching all data
+**Performance**: Slow for large tables with date filters
+**Files**: `ConstraintTranslator.java:498-502`
+
+### 7. Parallel Splits Disable Sorting
+**Issue**: ORDER BY disabled when using parallel splits
+**Reason**: Split-level sorting can't guarantee global order
+**Workaround**: Disable parallel splits for sorted queries
+**Files**: `BaseMetadataHandler.java:getPartitions()`
+
+---
+
+## Troubleshooting
+
+### Tests Fail to Connect
+
+**Symptom**: `AWS credentials not configured properly`
+
+**Solution**:
+```bash
+aws configure
+# Or set environment variables
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_SESSION_TOKEN=...  # If using temporary credentials
+```
+
+### Query Timeout
+
+**Symptom**: `Query timeout after 300s`
+
+**Possible Causes**:
+1. Large dataset without LIMIT
+2. Complex filters not pushed down
+3. Lambda cold start
+
+**Solutions**:
+- Increase timeout in script (edit `max_wait` variable)
+- Add LIMIT to queries
+- Enable filter pushdown for more types
+- Warm up Lambda with test query
+
+### Schema Not Found
+
+**Symptom**: `Database/table does not exist`
+
+**Solutions**:
+1. Check catalog registration:
+   ```bash
+   aws athena list-data-catalogs
+   ```
+2. Verify Lark Base credentials in Lambda environment
+3. Run Glue crawler to populate metadata
+4. Check table name sanitization (Glue converts special chars)
+
+### Type Mismatch Errors
+
+**Symptom**: `Cannot cast VARCHAR to ARRAY`
+
+**Possible Causes**:
+- Field type changed in Lark after schema discovery
+- Formula result type changed
+- Lookup target changed
+
+**Solutions**:
+1. Re-run Glue crawler to refresh schema
+2. Check `lark_field_type_mapping` in Glue table parameters
+3. Manually update Glue table schema if needed
+
+### Filter Pushdown Not Working
+
+**Symptom**: Queries slow despite WHERE clause
+
+**Verification**:
+```sql
+-- Check execution plan
+EXPLAIN SELECT * FROM table WHERE field = 'value';
+
+-- Check CloudWatch logs for Lambda
+-- Look for "filter_expression" in RecordHandler logs
+```
+
+**Common Issues**:
+- Field type not in pushdown whitelist (check `ConstraintTranslator.isUiTypeAllowedForPushdown()`)
+- Complex filter expressions (nested OR/AND)
+- Date/time filters (not supported)
+
+### NULL Values Returning Defaults
+
+**Symptom**: Expected NULL but getting empty string or 0
+
+**Explanation**: `BaseRecordHandler.getDefaultValueForType()` provides defaults:
+- VARCHAR → `""`
+- DECIMAL → `0`
+- BIT → `false`
+- DATEMILLI → `0` (1970-01-01)
+
+**Files**: `BaseRecordHandler.java:313-352`
+
+---
+
+## Files Reference
+
+### Key Source Files
+
+| File | Purpose | Line References |
+|------|---------|-----------------|
+| `BaseRecordHandler.java` | Data fetching & transformation | 313-352 (defaults), 252-254 (boolean) |
+| `ConstraintTranslator.java` | Filter & sort pushdown | 157-163 (checkbox null), 244-260 (text null), 498-502 (whitelist) |
+| `RegistererExtractor.java` | Type extractors | 244-260 (formula text), 324-355 (date detection) |
+| `LarkBaseTypeUtils.java` | Type mapping | Full file for mappings |
+| `UITypeEnum.java` | Lark type definitions | All type constants |
+| `BaseMetadataHandler.java` | Schema & partition logic | getPartitions(), doGetSplits() |
+| `LarkBaseService.java` | Lark API client | getLookupType() for recursion |
+
+### Test Files
+
+| File | Purpose |
+|------|---------|
+| `regression-test-plan.sh` | Main regression test script (51 tests) |
+| `REGRESSION_TESTING_GUIDE.md` | This document |
+| `glue-lark-base-crawler/src/test/**/*Test.java` | Unit tests for crawler |
+
+---
+
+## Contributing
+
+When adding new features or fixing bugs:
+
+1. **Update type mappings** in `LarkBaseTypeUtils.java`
+2. **Add filter support** in `ConstraintTranslator.java` if applicable
+3. **Register extractors** in `RegistererExtractor.java`
+4. **Add unit tests** in `athena-lark-base/src/test/`
+5. **Update this guide** with new edge cases
+6. **Add regression tests** to `regression-test-plan.sh`
+7. **Run full test suite** before submitting PR
+
+---
+
+## Quick Reference Commands
+
+```bash
+# Build project
+make build
+
+# Run unit tests
+make test
+
+# Show regression test setup
+./regression-test-plan.sh --setup
+
+# Run regression tests
+./regression-test-plan.sh
+
+# Deploy to AWS Lambda
+aws lambda update-function-code \
+  --function-name athena-lark-base-connector \
+  --zip-file fileb://target/athena-lark-base-connector.jar
+
+# Query from Athena CLI
+aws athena start-query-execution \
+  --query-string "SELECT * FROM lark_base_catalog.my_db.my_table LIMIT 10" \
+  --result-configuration "OutputLocation=s3://bucket/"
+
+# Get query results
+aws athena get-query-results --query-execution-id <execution-id>
+```
+
+---
+
+**End of Regression Testing Guide**

--- a/regression-test-plan.sh
+++ b/regression-test-plan.sh
@@ -1,0 +1,832 @@
+#!/bin/bash
+
+# ==============================================================================
+# Athena-Lark-Base Connector - Regression Testing Script
+# ==============================================================================
+#
+# Purpose: Comprehensive regression testing for all Lark Base data types
+# Comprehensive regression test suite for Athena Lark Base Connector
+# Last Updated: 2025-10-04
+#
+# This script tests the AWS Athena Query Federation connector for Lark Base
+# against all 26 supported data types and various edge cases.
+#
+# ==============================================================================
+
+set -e  # Exit on error
+
+# Load environment variables from .env if it exists
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Test configuration
+TEST_DATABASE="${TEST_DATABASE:-athena_lark_base_regression_test}"
+TEST_TABLE="${TEST_TABLE:-data_type_test_table}"
+ATHENA_WORKGROUP="${ATHENA_WORKGROUP:-primary}"
+ATHENA_CATALOG="${ATHENA_CATALOG:-your-catalog-name}"  # Federated query catalog
+OUTPUT_LOCATION="${OUTPUT_LOCATION:-}"  # Empty = use workgroup default
+REGION="${AWS_REGION:-us-east-1}"
+
+# Test results tracking
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+SKIPPED_TESTS=0
+
+# ==============================================================================
+# Helper Functions
+# ==============================================================================
+
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1" >&2
+}
+
+log_success() {
+    echo -e "${GREEN}[PASS]${NC} $1" >&2
+    ((PASSED_TESTS++)) || true
+}
+
+log_error() {
+    echo -e "${RED}[FAIL]${NC} $1" >&2
+    ((FAILED_TESTS++)) || true
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARN]${NC} $1" >&2
+}
+
+log_skip() {
+    echo -e "${YELLOW}[SKIP]${NC} $1" >&2
+    ((SKIPPED_TESTS++)) || true
+}
+
+# Execute Athena query and return query execution ID
+execute_athena_query() {
+    local query="$1"
+    local query_name="$2"
+
+    log_info "Executing: $query_name"
+
+    # Start query execution
+    if [[ -n "$OUTPUT_LOCATION" ]]; then
+        execution_id=$(aws athena start-query-execution \
+            --query-string "$query" \
+            --query-execution-context "Catalog=$ATHENA_CATALOG,Database=$TEST_DATABASE" \
+            --result-configuration "OutputLocation=$OUTPUT_LOCATION" \
+            --work-group "$ATHENA_WORKGROUP" \
+            --region "$REGION" \
+            --query 'QueryExecutionId' \
+            --output text 2>&1)
+    else
+        # Use workgroup's default output location
+        execution_id=$(aws athena start-query-execution \
+            --query-string "$query" \
+            --query-execution-context "Catalog=$ATHENA_CATALOG,Database=$TEST_DATABASE" \
+            --work-group "$ATHENA_WORKGROUP" \
+            --region "$REGION" \
+            --query 'QueryExecutionId' \
+            --output text 2>&1)
+    fi
+
+    if [[ $? -ne 0 ]]; then
+        log_error "Failed to start query: $query_name"
+        echo "$execution_id" >&2
+        return 1
+    fi
+
+    echo "$execution_id"
+}
+
+# Wait for query to complete and return status
+wait_for_query() {
+    local execution_id="$1"
+    local max_wait=300  # 5 minutes
+    local elapsed=0
+
+    while [[ $elapsed -lt $max_wait ]]; do
+        status=$(aws athena get-query-execution \
+            --query-execution-id "$execution_id" \
+            --region "$REGION" \
+            --query 'QueryExecution.Status.State' \
+            --output text 2>&1)
+
+        case "$status" in
+            SUCCEEDED)
+                return 0
+                ;;
+            FAILED|CANCELLED)
+                # Get error message
+                error=$(aws athena get-query-execution \
+                    --query-execution-id "$execution_id" \
+                    --region "$REGION" \
+                    --query 'QueryExecution.Status.StateChangeReason' \
+                    --output text 2>&1)
+                log_error "Query failed: $error"
+                return 1
+                ;;
+            QUEUED|RUNNING)
+                sleep 2
+                ((elapsed+=2))
+                ;;
+            *)
+                log_error "Unknown status: $status"
+                return 1
+                ;;
+        esac
+    done
+
+    log_error "Query timeout after ${max_wait}s"
+    return 1
+}
+
+# Get query results
+get_query_results() {
+    local execution_id="$1"
+
+    aws athena get-query-results \
+        --query-execution-id "$execution_id" \
+        --region "$REGION" \
+        --output json
+}
+
+# Run a test query
+run_test_query() {
+    local query="$1"
+    local test_name="$2"
+    local expected_result="$3"  # Optional: validate result if provided
+
+    ((TOTAL_TESTS++)) || true
+
+    execution_id=$(execute_athena_query "$query" "$test_name")
+    if [[ $? -ne 0 ]]; then
+        log_error "$test_name"
+        return 1
+    fi
+
+    if wait_for_query "$execution_id"; then
+        results=$(get_query_results "$execution_id")
+
+        # If expected result provided, validate
+        if [[ -n "$expected_result" ]]; then
+            if echo "$results" | grep -q "$expected_result"; then
+                log_success "$test_name"
+                return 0
+            else
+                log_error "$test_name - Result mismatch"
+                echo "Expected: $expected_result"
+                echo "Got: $results"
+                return 1
+            fi
+        else
+            log_success "$test_name"
+            return 0
+        fi
+    else
+        log_error "$test_name"
+        return 1
+    fi
+}
+
+# ==============================================================================
+# Pre-flight Checks
+# ==============================================================================
+
+preflight_checks() {
+    log_info "Running pre-flight checks..."
+
+    # Check AWS CLI
+    if ! command -v aws &> /dev/null; then
+        log_error "AWS CLI not found. Please install it first."
+        exit 1
+    fi
+
+    # Check AWS credentials
+    if ! aws sts get-caller-identity &> /dev/null; then
+        log_error "AWS credentials not configured properly."
+        exit 1
+    fi
+
+    # Verify Athena workgroup exists
+    if ! aws athena get-work-group --work-group "$ATHENA_WORKGROUP" --region "$REGION" &> /dev/null; then
+        log_warning "Workgroup '$ATHENA_WORKGROUP' not found. Using default."
+        ATHENA_WORKGROUP="primary"
+    fi
+
+    log_success "Pre-flight checks completed"
+}
+
+# ==============================================================================
+# Test Setup
+# ==============================================================================
+
+print_test_setup_instructions() {
+    cat <<EOF
+
+${BLUE}==============================================================================
+REGRESSION TEST SETUP INSTRUCTIONS
+==============================================================================${NC}
+
+Before running these tests, you need to create a test Lark Base with the
+following structure. This table should contain sample data for all supported
+data types.
+
+${YELLOW}Test Table Name:${NC} data_type_test_table
+${YELLOW}Required Fields:${NC}
+
+${GREEN}1. Primitive String Types:${NC}
+   - field_text (TEXT)
+   - field_barcode (BARCODE)
+   - field_single_select (SINGLE_SELECT)
+   - field_phone (PHONE)
+   - field_email (EMAIL)
+   - field_auto_number (AUTO_NUMBER)
+
+${GREEN}2. Numeric Types:${NC}
+   - field_number (NUMBER)
+   - field_progress (PROGRESS)
+   - field_currency (CURRENCY)
+   - field_rating (RATING)
+
+${GREEN}3. Boolean Type:${NC}
+   - field_checkbox (CHECKBOX)
+
+${GREEN}4. Date/Time Types:${NC}
+   - field_date_time (DATE_TIME)
+   - field_created_time (CREATED_TIME)
+   - field_modified_time (MODIFIED_TIME)
+
+${GREEN}5. Array Types:${NC}
+   - field_multi_select (MULTI_SELECT)
+   - field_user (USER)
+   - field_group_chat (GROUP_CHAT)
+   - field_attachment (ATTACHMENT)
+
+${GREEN}6. Link Types:${NC}
+   - field_single_link (SINGLE_LINK)
+   - field_duplex_link (DUPLEX_LINK)
+
+${GREEN}7. Struct Types:${NC}
+   - field_url (URL)
+   - field_location (LOCATION)
+   - field_created_user (CREATED_USER)
+   - field_modified_user (MODIFIED_USER)
+
+${GREEN}8. Complex Types:${NC}
+   - field_formula (FORMULA) - should compute from another field
+   - field_lookup (LOOKUP) - should reference another table
+
+${YELLOW}Sample Data Requirements:${NC}
+- At least 10 rows of test data
+- Include edge cases:
+  * NULL/empty values
+  * Maximum length strings
+  * Boundary numeric values (0, negative, very large)
+  * Past, present, and future dates
+  * Empty arrays
+  * Complex formulas (text, number, date results)
+  * Multi-level lookups
+
+${YELLOW}AWS Configuration:${NC}
+1. Deploy the Lark Base connector Lambda function
+2. Register the connector with Athena:
+   aws athena create-data-catalog \\
+     --name lark_base_catalog \\
+     --type LAMBDA \\
+     --parameters function=arn:aws:lambda:REGION:ACCOUNT:function:FUNCTION_NAME
+
+3. Run the Glue crawler to create catalog metadata (if using Glue integration)
+
+4. Set environment variables:
+   export TEST_DATABASE="lark_base_test"
+   export TEST_TABLE="data_type_test_table"
+   export OUTPUT_LOCATION="s3://your-bucket/athena-results/"
+   export AWS_REGION="us-east-1"
+
+${BLUE}==============================================================================${NC}
+
+EOF
+}
+
+# ==============================================================================
+# Test Categories
+# ==============================================================================
+
+# Category 1: Basic Data Type Reading Tests
+test_basic_data_types() {
+    log_info "==== Testing Basic Data Types ===="
+
+    # Test 1: TEXT field
+    run_test_query \
+        "SELECT field_text FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read TEXT field"
+
+    # Test 2: BARCODE field
+    run_test_query \
+        "SELECT field_barcode FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read BARCODE field"
+
+    # Test 3: SINGLE_SELECT field
+    run_test_query \
+        "SELECT field_single_select FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read SINGLE_SELECT field"
+
+    # Test 4: PHONE field
+    run_test_query \
+        "SELECT field_phone FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read PHONE field"
+
+    # Test 5: EMAIL field
+    run_test_query \
+        "SELECT field_email FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read EMAIL field"
+}
+
+# Category 2: Numeric Data Types
+test_numeric_data_types() {
+    log_info "==== Testing Numeric Data Types ===="
+
+    # Test 6: NUMBER field
+    run_test_query \
+        "SELECT field_number FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read NUMBER field"
+
+    # Test 7: PROGRESS field
+    run_test_query \
+        "SELECT field_progress FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read PROGRESS field"
+
+    # Test 8: CURRENCY field
+    run_test_query \
+        "SELECT field_currency FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read CURRENCY field"
+
+    # Test 9: RATING field
+    run_test_query \
+        "SELECT field_rating FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read RATING field"
+
+    # Test 10: Numeric aggregations
+    run_test_query \
+        "SELECT AVG(field_number), SUM(field_currency), MAX(field_rating) FROM \"$TEST_DATABASE\".\"$TEST_TABLE\"" \
+        "Numeric aggregations"
+}
+
+# Category 3: Boolean and Date Types
+test_boolean_and_date_types() {
+    log_info "==== Testing Boolean and Date Types ===="
+
+    # Test 11: CHECKBOX field
+    run_test_query \
+        "SELECT field_checkbox FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read CHECKBOX field"
+
+    # Test 12: DATE_TIME field
+    run_test_query \
+        "SELECT field_date_time FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read DATE_TIME field"
+
+    # Test 13: CREATED_TIME field
+    run_test_query \
+        "SELECT field_created_time FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read CREATED_TIME field"
+
+    # Test 14: MODIFIED_TIME field
+    run_test_query \
+        "SELECT field_modified_time FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read MODIFIED_TIME field"
+
+    # Test 15: Date functions
+    run_test_query \
+        "SELECT date_format(field_date_time, '%Y-%m-%d') FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Date formatting"
+}
+
+# Category 4: Array/List Types
+test_array_types() {
+    log_info "==== Testing Array Types ===="
+
+    # Test 16: MULTI_SELECT field
+    run_test_query \
+        "SELECT field_multi_select FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read MULTI_SELECT array"
+
+    # Test 17: USER field
+    run_test_query \
+        "SELECT field_user FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read USER array"
+
+    # Test 18: GROUP_CHAT field
+    run_test_query \
+        "SELECT field_group_chat FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read GROUP_CHAT array"
+
+    # Test 19: ATTACHMENT field
+    run_test_query \
+        "SELECT field_attachment FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read ATTACHMENT array"
+
+    # Test 20: Array size
+    run_test_query \
+        "SELECT cardinality(field_multi_select) as array_size FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Array cardinality function"
+}
+
+# Category 5: Struct Types
+test_struct_types() {
+    log_info "==== Testing Struct Types ===="
+
+    # Test 21: URL field
+    run_test_query \
+        "SELECT field_url FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read URL struct"
+
+    # Test 22: URL field nested access
+    run_test_query \
+        "SELECT field_url.link, field_url.text FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Access URL struct fields"
+
+    # Test 23: LOCATION field
+    run_test_query \
+        "SELECT field_location FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read LOCATION struct"
+
+    # Test 24: LOCATION nested access
+    run_test_query \
+        "SELECT field_location.address, field_location.full_address FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Access LOCATION struct fields"
+
+    # Test 25: CREATED_USER field
+    run_test_query \
+        "SELECT field_created_user.name, field_created_user.email FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Access CREATED_USER struct fields"
+}
+
+# Category 6: Complex Types (Formula, Lookup, Links)
+test_complex_types() {
+    log_info "==== Testing Complex Types ===="
+
+    # Test 26: FORMULA field
+    run_test_query \
+        "SELECT field_formula FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read FORMULA field"
+
+    # Test 27: LOOKUP field
+    run_test_query \
+        "SELECT field_lookup FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read LOOKUP field"
+
+    # Test 28: SINGLE_LINK field
+    run_test_query \
+        "SELECT field_single_link FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read SINGLE_LINK field"
+
+    # Test 29: DUPLEX_LINK field
+    run_test_query \
+        "SELECT field_duplex_link FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read DUPLEX_LINK field"
+}
+
+# Category 7: Filter Pushdown Tests
+test_filter_pushdown() {
+    log_info "==== Testing Filter Pushdown ===="
+
+    # Test 30: TEXT equality filter
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_text = 'test_value'" \
+        "TEXT equality filter (pushdown)"
+
+    # Test 31: NUMBER range filter
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_number > 100 AND field_number <= 1000" \
+        "NUMBER range filter (pushdown)"
+
+    # Test 32: CHECKBOX filter
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_checkbox = true" \
+        "CHECKBOX true filter (pushdown)"
+
+    # Test 33: CHECKBOX IS NULL
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_checkbox IS NULL" \
+        "CHECKBOX IS NULL filter (pushdown converts to false)"
+
+    # Test 34: SINGLE_SELECT IN filter
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_single_select IN ('option1', 'option2')" \
+        "SINGLE_SELECT IN filter (pushdown)"
+
+    # Test 35: TEXT NOT EQUAL filter
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_text != 'excluded_value'" \
+        "TEXT NOT EQUAL filter (pushdown)"
+
+    # Test 36: Combined filters
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_number > 50 AND field_checkbox = true" \
+        "Combined AND filters (pushdown)"
+}
+
+# Category 8: Sort and Limit Pushdown Tests
+test_sort_and_limit_pushdown() {
+    log_info "==== Testing Sort and Limit Pushdown ===="
+
+    # Test 37: ORDER BY single field
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" ORDER BY field_number DESC LIMIT 10" \
+        "ORDER BY + LIMIT (Top-N pushdown)"
+
+    # Test 38: LIMIT only
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "LIMIT only (pushdown)"
+
+    # Test 39: ORDER BY multiple fields
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" ORDER BY field_created_time DESC, field_text ASC LIMIT 10" \
+        "Multi-field ORDER BY + LIMIT"
+}
+
+# Category 9: NULL Handling Tests
+test_null_handling() {
+    log_info "==== Testing NULL Handling ===="
+
+    # Test 40: TEXT IS NULL
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_text IS NULL" \
+        "TEXT IS NULL check"
+
+    # Test 41: TEXT IS NOT NULL (should add empty string check)
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_text IS NOT NULL" \
+        "TEXT IS NOT NULL check"
+
+    # Test 42: NUMBER IS NULL
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_number IS NULL" \
+        "NUMBER IS NULL check"
+
+    # Test 43: COALESCE with default values
+    run_test_query \
+        "SELECT COALESCE(field_text, 'default_value') FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "COALESCE for NULL handling"
+}
+
+# Category 10: Edge Cases and Stress Tests
+test_edge_cases() {
+    log_info "==== Testing Edge Cases ===="
+
+    # Test 44: Empty array handling
+    run_test_query \
+        "SELECT field_multi_select FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE cardinality(field_multi_select) = 0" \
+        "Empty array handling"
+
+    # Test 45: Large result set (pagination)
+    run_test_query \
+        "SELECT COUNT(*) as total_rows FROM \"$TEST_DATABASE\".\"$TEST_TABLE\"" \
+        "Count all rows (pagination test)"
+
+    # Test 46: Complex nested access
+    run_test_query \
+        "SELECT field_user[1].email, field_attachment[1].name FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Array element access"
+
+    # Test 47: All fields together
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 1" \
+        "Read all fields in single query"
+
+    # Test 48: Reserved fields
+    run_test_query \
+        "SELECT \\$reserved_record_id, \\$reserved_table_id, \\$reserved_base_id FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read reserved system fields"
+}
+
+# Category 11: Data Type Conversion Tests
+test_data_type_conversions() {
+    log_info "==== Testing Data Type Conversions ===="
+
+    # Test 49: CAST operations
+    run_test_query \
+        "SELECT CAST(field_number AS VARCHAR) FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "CAST number to string"
+
+    # Test 50: Date to string conversion
+    run_test_query \
+        "SELECT CAST(field_date_time AS VARCHAR) FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "CAST date to string"
+
+    # Test 51: Boolean to integer
+    run_test_query \
+        "SELECT CAST(field_checkbox AS INTEGER) FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "CAST boolean to integer"
+}
+
+# Category 12: Additional Fields Tests (User-Added Fields)
+test_additional_fields() {
+    log_info "==== Testing Additional User-Added Fields ===="
+
+    # Test 49: Additional CURRENCY fields
+    run_test_query \
+        "SELECT field_currency_2, field_currency_3 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional CURRENCY fields"
+
+    # Test 50: Additional DATE_TIME fields
+    run_test_query \
+        "SELECT field_date_time_2, field_date_time_3, field_date_time_4 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional DATE_TIME fields (2-4)"
+
+    # Test 51: More DATE_TIME fields
+    run_test_query \
+        "SELECT field_date_time_5, field_date_time_6, field_date_time_7 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional DATE_TIME fields (5-7)"
+
+    # Test 52: Final DATE_TIME fields
+    run_test_query \
+        "SELECT field_date_time_8, field_date_time_9 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional DATE_TIME fields (8-9)"
+
+    # Test 53: Additional PROGRESS fields
+    run_test_query \
+        "SELECT field_progress_2, field_progress_3, field_progress_4 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional PROGRESS fields"
+
+    # Test 54: Additional RATING field
+    run_test_query \
+        "SELECT field_rating_2 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional RATING field"
+
+    # Test 55: Additional GROUP_CHAT field
+    run_test_query \
+        "SELECT field_group_chat_2 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional GROUP_CHAT field"
+
+    # Test 56: Additional FORMULA fields (various types)
+    run_test_query \
+        "SELECT field_formula_2, field_formula_3 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional FORMULA fields (text/timestamp)"
+
+    # Test 57: More FORMULA fields (numeric)
+    run_test_query \
+        "SELECT field_formula_4, field_formula_5, field_formula_6 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional FORMULA fields (decimal)"
+
+    # Test 58: Final FORMULA field (rating type)
+    run_test_query \
+        "SELECT field_formula_7 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read additional FORMULA field (tinyint)"
+
+    # Test 59: Record ID field
+    run_test_query \
+        "SELECT record_id FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Read record_id field"
+
+    # Test 60: Aggregations on additional numeric fields
+    run_test_query \
+        "SELECT AVG(field_currency_2), SUM(field_progress_2), MAX(field_rating_2) FROM \"$TEST_DATABASE\".\"$TEST_TABLE\"" \
+        "Aggregations on additional numeric fields"
+
+    # Test 61: Date functions on additional timestamp fields
+    run_test_query \
+        "SELECT date_format(field_date_time_2, '%Y-%m-%d'), date_format(field_formula_3, '%Y-%m-%d') FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Date formatting on additional timestamp fields"
+
+    # Test 62: Filter on additional fields
+    run_test_query \
+        "SELECT * FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE field_progress_2 > 0.5 AND field_rating_2 >= 3" \
+        "Filter on additional numeric fields"
+}
+
+# ==============================================================================
+# Main Test Execution
+# ==============================================================================
+
+main() {
+    echo "[DEBUG] main() function started" >&2
+    echo ""
+    echo "================================================================================"
+    echo "  Athena-Lark-Base Connector - Regression Test Suite"
+    echo "================================================================================"
+    echo ""
+    echo "Configuration:"
+    echo "  Catalog: $ATHENA_CATALOG"
+    echo "  Database: $TEST_DATABASE"
+    echo "  Table: $TEST_TABLE"
+    echo "  Workgroup: $ATHENA_WORKGROUP"
+    echo "  Region: $REGION"
+    echo "  Output Location: $OUTPUT_LOCATION"
+    echo ""
+    echo "================================================================================"
+    echo ""
+
+    # Check if setup instructions should be shown
+    if [[ "$1" == "--setup" ]]; then
+        print_test_setup_instructions
+        exit 0
+    fi
+
+    # Confirm before running
+    read -p "Do you want to proceed with the tests? (y/n) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        log_warning "Tests cancelled by user"
+        exit 0
+    fi
+
+    # Run pre-flight checks
+    echo "[DEBUG] About to run preflight_checks" >&2
+    preflight_checks
+    echo "[DEBUG] Finished preflight_checks" >&2
+
+    # Start testing
+    echo "[DEBUG] About to set start_time" >&2
+    local start_time=$(date +%s)
+    echo "[DEBUG] start_time=$start_time" >&2
+
+    # Run all test categories
+    echo "[DEBUG] Starting test_basic_data_types..."
+    test_basic_data_types
+    echo "[DEBUG] Finished test_basic_data_types"
+    test_numeric_data_types
+    test_boolean_and_date_types
+    test_array_types
+    test_struct_types
+    test_complex_types
+    test_filter_pushdown
+    test_sort_and_limit_pushdown
+    test_null_handling
+    test_edge_cases
+    test_data_type_conversions
+    test_additional_fields
+
+    local end_time=$(date +%s)
+    local duration=$((end_time - start_time))
+
+    # Print summary
+    echo ""
+    echo "================================================================================"
+    echo "  Test Summary"
+    echo "================================================================================"
+    echo "  Total Tests: $TOTAL_TESTS"
+    echo -e "  ${GREEN}Passed: $PASSED_TESTS${NC}"
+    echo -e "  ${RED}Failed: $FAILED_TESTS${NC}"
+    echo -e "  ${YELLOW}Skipped: $SKIPPED_TESTS${NC}"
+    echo "  Duration: ${duration}s"
+    echo "================================================================================"
+    echo ""
+
+    if [[ $FAILED_TESTS -eq 0 ]]; then
+        log_success "All tests passed!"
+        exit 0
+    else
+        log_error "$FAILED_TESTS test(s) failed"
+        exit 1
+    fi
+}
+
+# ==============================================================================
+# Script Entry Point
+# ==============================================================================
+
+# Handle command line arguments
+case "${1:-}" in
+    --setup)
+        print_test_setup_instructions
+        ;;
+    --help|-h)
+        cat <<EOF
+Usage: $0 [OPTIONS]
+
+Regression test suite for Athena-Lark-Base connector
+
+Options:
+  --setup       Show test setup instructions
+  --help, -h    Show this help message
+
+Environment Variables:
+  TEST_DATABASE        Athena database name (default: lark_base_test)
+  TEST_TABLE           Test table name (default: data_type_test_table)
+  ATHENA_WORKGROUP     Athena workgroup (default: primary)
+  OUTPUT_LOCATION      S3 path for query results (required)
+  AWS_REGION           AWS region (default: us-east-1)
+
+Examples:
+  # Show setup instructions
+  $0 --setup
+
+  # Run tests with custom configuration
+  TEST_DATABASE=my_db TEST_TABLE=my_table OUTPUT_LOCATION=s3://my-bucket/ $0
+
+EOF
+        ;;
+    *)
+        main "$@"
+        ;;
+esac

--- a/test-timestamp-regression.sh
+++ b/test-timestamp-regression.sh
@@ -1,0 +1,245 @@
+#!/bin/bash
+
+# ==============================================================================
+# Timestamp/Date Regression Tests
+# ==============================================================================
+# Purpose: Targeted regression testing for timestamp/date type fixes
+# ==============================================================================
+
+set -e
+
+# Load environment from .env
+if [ -f .env ]; then
+    export $(grep -v '^#' .env | xargs)
+fi
+
+# Color codes
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Test configuration
+TEST_DATABASE="${TEST_DATABASE:-athena_lark_base_regression_test}"
+TEST_TABLE="${TEST_TABLE:-data_type_test_table}"
+ATHENA_WORKGROUP="${ATHENA_WORKGROUP:-poweruser}"
+ATHENA_CATALOG="${ATHENA_CATALOG:-your-catalog-name}"
+OUTPUT_LOCATION="${OUTPUT_LOCATION:-}"
+REGION="${AWS_REGION:-ap-southeast-1}"
+
+# Test results
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+log_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+log_success() { echo -e "${GREEN}[PASS]${NC} $1"; ((PASSED_TESTS++)) || true; }
+log_error() { echo -e "${RED}[FAIL]${NC} $1"; ((FAILED_TESTS++)) || true; }
+
+execute_athena_query() {
+    local query="$1"
+    local query_name="$2"
+
+    log_info "Executing: $query_name" >&2
+
+    if [[ -n "$OUTPUT_LOCATION" ]]; then
+        execution_id=$(aws athena start-query-execution \
+            --query-string "$query" \
+            --query-execution-context "Catalog=$ATHENA_CATALOG,Database=$TEST_DATABASE" \
+            --result-configuration "OutputLocation=$OUTPUT_LOCATION" \
+            --work-group "$ATHENA_WORKGROUP" \
+            --region "$REGION" \
+            --query 'QueryExecutionId' \
+            --output text)
+    else
+        execution_id=$(aws athena start-query-execution \
+            --query-string "$query" \
+            --query-execution-context "Catalog=$ATHENA_CATALOG,Database=$TEST_DATABASE" \
+            --work-group "$ATHENA_WORKGROUP" \
+            --region "$REGION" \
+            --query 'QueryExecutionId' \
+            --output text)
+    fi
+
+    echo "$execution_id"
+}
+
+wait_for_query() {
+    local execution_id="$1"
+    local max_wait=300
+    local elapsed=0
+
+    while [[ $elapsed -lt $max_wait ]]; do
+        status=$(aws athena get-query-execution \
+            --query-execution-id "$execution_id" \
+            --region "$REGION" \
+            --query 'QueryExecution.Status.State' \
+            --output text)
+
+        case "$status" in
+            SUCCEEDED) return 0 ;;
+            FAILED|CANCELLED)
+                error=$(aws athena get-query-execution \
+                    --query-execution-id "$execution_id" \
+                    --region "$REGION" \
+                    --query 'QueryExecution.Status.StateChangeReason' \
+                    --output text)
+                log_error "Query failed: $error" >&2
+                return 1
+                ;;
+            QUEUED|RUNNING)
+                sleep 2
+                ((elapsed+=2))
+                ;;
+            *)
+                log_error "Unknown status: $status" >&2
+                return 1
+                ;;
+        esac
+    done
+
+    log_error "Query timeout after ${max_wait}s" >&2
+    return 1
+}
+
+get_query_results() {
+    local execution_id="$1"
+    aws athena get-query-results \
+        --query-execution-id "$execution_id" \
+        --region "$REGION" \
+        --output json
+}
+
+run_test_query() {
+    local query="$1"
+    local test_name="$2"
+
+    ((TOTAL_TESTS++)) || true
+
+    execution_id=$(execute_athena_query "$query" "$test_name")
+    if [[ $? -ne 0 ]]; then
+        log_error "$test_name - Query execution failed"
+        return 1
+    fi
+
+    if wait_for_query "$execution_id"; then
+        results=$(get_query_results "$execution_id")
+
+        # Log results
+        echo "Results:"
+        echo "$results" | jq -r '.ResultSet.Rows[] | .Data | map(.VarCharValue // "NULL") | @csv'
+
+        log_success "$test_name"
+        return 0
+    else
+        log_error "$test_name - Query execution failed or timed out"
+        return 1
+    fi
+}
+
+# ==============================================================================
+# Timestamp/Date Tests
+# ==============================================================================
+
+test_timestamp_fields() {
+    log_info "==== Testing Timestamp/Date Fields ===="
+
+    # Test 1: DATE_TIME field - Read values
+    run_test_query \
+        "SELECT field_date_time FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 10" \
+        "Test 1: Read DATE_TIME field (10 rows)"
+
+    # Test 2: CREATED_TIME field
+    run_test_query \
+        "SELECT field_created_time FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Test 2: Read CREATED_TIME field"
+
+    # Test 3: MODIFIED_TIME field
+    run_test_query \
+        "SELECT field_modified_time FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Test 3: Read MODIFIED_TIME field"
+
+    # Test 4: Additional DATE_TIME fields (field_date_time_2 through field_date_time_9)
+    run_test_query \
+        "SELECT field_date_time_2, field_date_time_3, field_date_time_4 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Test 4: Read additional DATE_TIME fields (2-4)"
+
+    run_test_query \
+        "SELECT field_date_time_5, field_date_time_6, field_date_time_7 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Test 5: Read additional DATE_TIME fields (5-7)"
+
+    run_test_query \
+        "SELECT field_date_time_8, field_date_time_9 FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Test 6: Read additional DATE_TIME fields (8-9)"
+
+    # Test 7: Date formatting
+    run_test_query \
+        "SELECT date_format(field_date_time, '%Y-%m-%d %H:%i:%s') as formatted_date FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Test 7: Date formatting on DATE_TIME"
+
+    # Test 8: Formula timestamp fields
+    run_test_query \
+        "SELECT field_formula_3, date_format(field_formula_3, '%Y-%m-%d') as formatted_formula FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 5" \
+        "Test 8: Formula timestamp field (field_formula_3)"
+
+    # Test 9: Range check - Past dates (1995)
+    run_test_query \
+        "SELECT field_date_time, date_format(field_date_time, '%Y') as year FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE date_format(field_date_time, '%Y') = '1995' LIMIT 5" \
+        "Test 9: Past dates (1995) verification"
+
+    # Test 10: Range check - Future dates (2035)
+    run_test_query \
+        "SELECT field_date_time, date_format(field_date_time, '%Y') as year FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" WHERE date_format(field_date_time, '%Y') = '2035' LIMIT 5" \
+        "Test 10: Future dates (2035) verification"
+
+    # Test 11: Timestamp comparisons
+    run_test_query \
+        "SELECT COUNT(*) as count, MIN(field_date_time) as min_date, MAX(field_date_time) as max_date FROM \"$TEST_DATABASE\".\"$TEST_TABLE\"" \
+        "Test 11: Timestamp aggregations (min/max)"
+
+    # Test 12: All timestamp fields together
+    run_test_query \
+        "SELECT field_date_time, field_created_time, field_modified_time FROM \"$TEST_DATABASE\".\"$TEST_TABLE\" LIMIT 3" \
+        "Test 12: All main timestamp fields together"
+}
+
+# ==============================================================================
+# Main Execution
+# ==============================================================================
+
+echo "================================================================================"
+echo "  Timestamp/Date Regression Tests"
+echo "================================================================================"
+echo ""
+echo "Configuration:"
+echo "  Catalog: $ATHENA_CATALOG"
+echo "  Database: $TEST_DATABASE"
+echo "  Table: $TEST_TABLE"
+echo "  Workgroup: $ATHENA_WORKGROUP"
+echo "  Region: $REGION"
+echo ""
+echo "================================================================================"
+echo ""
+
+# Run tests
+test_timestamp_fields
+
+# Print summary
+echo ""
+echo "================================================================================"
+echo "  Test Summary"
+echo "================================================================================"
+echo "  Total Tests: $TOTAL_TESTS"
+echo -e "  ${GREEN}Passed: $PASSED_TESTS${NC}"
+echo -e "  ${RED}Failed: $FAILED_TESTS${NC}"
+echo "================================================================================"
+echo ""
+
+if [[ $FAILED_TESTS -eq 0 ]]; then
+    log_success "All timestamp/date tests passed!"
+    exit 0
+else
+    log_error "$FAILED_TESTS timestamp/date test(s) failed"
+    exit 1
+fi

--- a/verify-timestamps.sh
+++ b/verify-timestamps.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+exec_id=$(aws athena start-query-execution \
+  --query-string "SELECT field_date_time FROM athena_lark_base_regression_test.data_type_test_table WHERE field_date_time IS NOT NULL ORDER BY field_date_time LIMIT 10" \
+  --query-execution-context "Catalog=your-catalog-name,Database=athena_lark_base_regression_test" \
+  --work-group poweruser \
+  --region ap-southeast-1 \
+  --query 'QueryExecutionId' \
+  --output text)
+
+echo "Query execution ID: $exec_id"
+sleep 10
+
+aws athena get-query-results \
+  --query-execution-id "$exec_id" \
+  --region ap-southeast-1 \
+  --output json | jq -r '.ResultSet.Rows[] | .Data | map(.VarCharValue // "NULL") | @csv'


### PR DESCRIPTION
Improved the timestamp format detection heuristic to correctly handle timestamps across different date ranges and formats, ensuring proper display in Athena queries.

Changes:
- Improved milliseconds threshold from 10^12 to 10^10 (March 1973+) to correctly handle dates before 2001
- Added seconds threshold at 100,000 to better distinguish Unix timestamps from Excel serial dates
- Added DATEMILLI case to handle Arrow Date(MILLISECOND) type from Glue timestamp schema
- Enhanced logging for timestamp conversion debugging
- Refactored checkbox extractor for cleaner code
- Removed unused EXCEL_DATE_HEURISTIC_THRESHOLD constant

The fix applies to all three data source activation methods:
1. Glue Crawler (default_does_not_activate_*)
2. Lark Base/Drive Source (default_does_activate_lark_base_source)
3. Experimental Feature (default_does_activate_experimental_feature)

All paths use the same timestamp extraction logic via RegistererExtractor.registerDateMilliExtractor(), ensuring consistent behavior regardless of metadata source.

Timestamps now display correctly as human-readable dates (e.g., "2025-10-04 18:21:21.623") instead of bigint values, while maintaining the timestamp type in Athena and Glue schemas.

Tested with dates ranging from 1995 to 2035, confirming proper ordering and formatting.