### PR TITLE
Fix: nullPointerException Record Deserialization on Latest Lark API Deployment

### DIFF
--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/model/response/ListRecordsResponse.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/model/response/ListRecordsResponse.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Response for List Records
@@ -72,7 +73,16 @@ public final class ListRecordsResponse extends BaseResponse<ListRecordsResponse.
         private RecordItem(Builder builder)
         {
             this.recordId = builder.recordId;
-            this.fields = builder.fields != null ? Map.copyOf(builder.fields) : Collections.emptyMap();
+            // Ensure immutable map, filter out null values (Lark now returns null for empty cells)
+            if (builder.fields != null) {
+                Map<String, Object> nonNullFields = builder.fields.entrySet().stream()
+                        .filter(e -> e.getValue() != null)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                this.fields = Map.copyOf(nonNullFields);
+            }
+            else {
+                this.fields = Collections.emptyMap();
+            }
         }
 
         @JsonProperty("record_id")

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/model/response/ListRecordsResponseTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/model/response/ListRecordsResponseTest.java
@@ -22,6 +22,7 @@ package com.amazonaws.glue.lark.base.crawler.model.response;
 import org.junit.Test;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +42,24 @@ public class ListRecordsResponseTest {
 
         assertEquals(recordId, item.getRecordId());
         assertEquals(fields, item.getFields());
+    }
+
+    @Test
+    public void recordItem_fields_whenValuesAreNull_shouldFilterThemOut() {
+        Map<String, Object> fieldsWithNull = new HashMap<>();
+        fieldsWithNull.put("name", "Alice");
+        fieldsWithNull.put("email", null);
+        fieldsWithNull.put("age", 25);
+
+        ListRecordsResponse.RecordItem item = ListRecordsResponse.RecordItem.builder()
+                .recordId("rec_with_null")
+                .fields(fieldsWithNull)
+                .build();
+
+        assertEquals(2, item.getFields().size());
+        assertTrue(item.getFields().containsKey("name"));
+        assertTrue(item.getFields().containsKey("age"));
+        assertFalse(item.getFields().containsKey("email"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #19.

## Description
glue-lark-base-crawler's ListRecordsResponse.RecordItem constructor threw NullPointerException when deserializing the Lark Base List Records API response if any cell had a null value. Map.copyOf(builder.fields) rejects null values, so the first null-valued cell crashed the crawler.

This is fix-drift: athena-lark-base already handles this correctly. The Lark Base Search Records API changed — empty columns used to be omitted from fields entirely, but are now returned with an explicit null value, exposing the latent bug.

## Changes
- ListRecordsResponse.RecordItem now filters out null-valued entries before building the immutable map, mirroring the existing athena-lark-base implementation. This restores the old effective behavior (empty columns absent from the map), so downstream fields.get(key) consumers are unaffected.
- Added a regression test (recordItem_fields_whenValuesAreNull_shouldFilterThemOut) asserting null values are dropped while non-null values are retained.
