### PR TITLE
Fix several query correctness and metadata discovery bugs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -808,6 +808,14 @@ MODIFIED_BY         STRUCT                   Person struct extractor
 | AUTO_NUMBER | VARCHAR | Auto-generated number |
 | DUPLEX_LINK | LIST<STRUCT<record_id:VARCHAR, text:VARCHAR>> | Bidirectional links |
 
+### Known Limitations
+
+**NUMBER field precision**: Lark Base stores `Number`/`Progress`/`Currency`/`Rating` field values as IEEE 754 double-precision floats internally. Values exceeding ~15-17 significant digits (e.g. bank card numbers, long numeric IDs) are already rounded by Lark Base itself - trailing digits become zeros - before the Search Records API ever returns the data. This connector maps NUMBER to `Decimal(38, 18)`, which is more than wide enough to hold the value once received, but it cannot recover precision Lark Base already discarded upstream. Confirmed by direct API testing: sending `12345678901234567890` (20 digits) round-trips through Lark's Search Records API as `12345678901234500000`. Lark's own FAQ documents this and recommends storing such values in a `Text` field instead: see [Base limits FAQs](https://www.larksuite.com/hc/en-US/articles/890398616778-base-limits-faqs).
+
+**LOOKUP field type resolution** (fixed): `LarkBaseTableResolver` and `ExperimentalMetadataProvider` (the "Lark Base Source" and "Experimental" discovery paths) previously guarded LOOKUP resolution with `field.getFormulaGlueCatalogUITypeEnum().equals(LOOKUP)`, which can only be true for FORMULA fields, then called `getTargetFieldAndTableForLookup()`, which only returns a usable target for LOOKUP fields - a self-contradictory condition that made the branch dead code. A genuine LOOKUP field's child type was always left `UNKNOWN`, and `LarkBaseTypeUtils.larkFieldToArrowMinorType` had no `case LOOKUP` at all, so the field's top-level Arrow type fell through to `default -> VARCHAR` instead of `LIST`. Both are now fixed: the resolvers branch on the field's own UI type (matching `glue-lark-base-crawler`'s correct logic), and LOOKUP now maps to `LIST` with its child element type derived from the resolved target (`Decimal` for NUMBER/PROGRESS/CURRENCY, `Bool` for CHECKBOX, `Timestamp` for DATE_TIME family, `TinyInt` for RATING, `Utf8` otherwise - matching the Glue Crawler path's `array<{target type}>` semantics).
+
+**Chained LOOKUP type parsing from Glue comments** (fixed): the Glue Crawler encodes a LOOKUP field's resolved type in the column comment as `LarkBaseFieldType=Lookup<{target type}>`, and recurses to a nested string like `Lookup<Lookup<Number>>` when the LOOKUP's target is itself another LOOKUP field (`BaseLarkBaseCrawlerHandler.getLarkBaseOriginalColumnType`). `CommonUtil.extractFormulaOrLookup`, which parses this comment back out on the primary Glue Catalog discovery path, used to split on the *first* `<` and take index `[1]`, which only ever captured the immediate next level ("Lookup") instead of the terminal type ("Number") for any chain of depth 2+. Fixed to extract from the *last* `<` instead, which always yields the innermost/terminal type regardless of nesting depth.
+
 ### Reserved Fields
 
 All tables automatically include these fields:
@@ -932,6 +940,13 @@ Translated to Lark API:
 - Faster query execution for large tables
 - Better Lambda concurrency utilization
 - Reduced individual Lambda memory pressure
+
+**Filter selectivity check**: Splits are sized off the table's full row count, because `$reserved_split_key`
+is a positional index over the whole table rather than over filtered results - a selective filter can match
+rows anywhere in that key range, so splits must cover it entirely to stay correct. Before committing to
+parallel splitting, the connector runs a cheap `pageSize=1` count query with the filter applied; if the
+matching row count already fits in a single page, it falls back to a single partition instead of spawning
+splits that would mostly return zero rows (e.g. `WHERE id = 'x'` on a 100,000-row table).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ All Lark Base field types are supported:
 - **Advanced**: Attachment, Person, Location, Formula
 - **Special**: Lookup (with recursive resolution), Duplex Link, Auto Number
 
+### Known Limitations
+
+- **NUMBER field precision**: Lark Base stores `Number` field values as IEEE 754 double-precision floats, which only preserve about 15-17 significant digits. Values that exceed this (e.g. bank card numbers, long numeric IDs) are silently rounded by Lark Base itself - trailing digits are replaced with zeros - before the data ever reaches this connector. This is a Lark Base platform limitation, not a connector bug, and it cannot be corrected downstream by the connector. Per [Lark's own documentation](https://www.larksuite.com/hc/en-US/articles/890398616778-base-limits-faqs): *"To record information containing large numbers, such as bank card numbers, use the text field."* If you need exact large numbers or high-precision decimals, store them in a `Text` field in Lark Base instead of a `Number` field.
+
 ## Architecture
 
 ```
@@ -208,6 +212,7 @@ JAVA_HOME="/path/to/jdk-17" mvn checkstyle:check
 | `ACTIVATE_LARK_BASE_SOURCE` | No | Enable Lark Base metadata discovery |
 | `ACTIVATE_PARALLEL_SPLIT` | No | Enable parallel split execution |
 | `ENABLE_DEBUG_LOGGING` | No | Enable detailed debug logs |
+| `LARK_LOOKUP_MAX_DEPTH` | No | Max hops followed when resolving a chained LOOKUP field's type (default: 20). Also caps runaway resolution if a Lark Base has a misconfigured circular LOOKUP reference |
 
 See [ARCHITECTURE.md#Configuration](./ARCHITECTURE.md#configuration) for complete reference.
 

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseConstants.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseConstants.java
@@ -63,6 +63,19 @@ public final class BaseConstants
     public static final String ENABLE_DEBUG_LOGGING_ENV_VAR = "default_enable_debug_logging";
 
     /**
+     * The environment variable which is used to cap how many LOOKUP hops the connector will follow when resolving
+     * a chained LOOKUP field's effective type (e.g. a LOOKUP pointing at another LOOKUP in a different table).
+     * This is a defense-in-depth safety valve on top of cycle detection, in case a legitimate (non-circular) chain
+     * is unexpectedly deep. Defaults to {@code DEFAULT_LARK_LOOKUP_MAX_DEPTH} if unset or not a positive integer.
+     */
+    public static final String LARK_LOOKUP_MAX_DEPTH_ENV_VAR = "default_lark_lookup_max_depth";
+
+    /**
+     * Default value for {@link #LARK_LOOKUP_MAX_DEPTH_ENV_VAR} when the environment variable is not set.
+     */
+    public static final int DEFAULT_LARK_LOOKUP_MAX_DEPTH = 20;
+
+    /**
      * The environment variable which is used to set the default lark base sources for the connector.
      * If we use this, we can ignore crawler and use the lark base sources directly.
      * format: [larkBaseId:larkTableId1,larkBaseId:larkTableId2,...]

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandler.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandler.java
@@ -142,7 +142,7 @@ public class BaseMetadataHandler
         this.invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
         this.envVarService = new EnvVarService(configOptions, invoker);
         AthenaService athenaService = new AthenaService();
-        this.larkBaseService = new LarkBaseService(envVarService.getLarkAppId(), envVarService.getLarkAppSecret());
+        this.larkBaseService = new LarkBaseService(envVarService.getLarkAppId(), envVarService.getLarkAppSecret(), envVarService.getLookupMaxDepth());
         LarkDriveService larkDriveService = new LarkDriveService(envVarService.getLarkAppId(), envVarService.getLarkAppSecret());
         this.glueCatalogService = new GlueCatalogService(getAwsGlue());
         LarkBaseTableResolver larkBaseTableResolver = new LarkBaseTableResolver(
@@ -405,7 +405,7 @@ public class BaseMetadataHandler
 
         if (envVarService.isActivateExperimentalFeatures()) {
             if (envVarService.isEnableDebugLogging()) {
-                logger.info("doGetTable: Experimental feature is not active (envVarService.isActivateExperimentalFeatures()=false).");
+                logger.info("doGetTable: Attempting to get schema from experimental path (envVarService.isActivateExperimentalFeatures()=true).");
             }
             Optional<TableSchemaResult> schemaResult = experimentalMetadataProvider.getTableSchema(request);
             if (schemaResult.isPresent()) {
@@ -746,7 +746,9 @@ public class BaseMetadataHandler
         boolean hasOrderBy = hasOrderByClause(request);
         String sortExpression = translateSortExpression(request, fieldNameMappings, useParallelSplits, hasOrderBy, tableName);
 
-        if (useParallelSplits && envVarService.isActivateParallelSplit()) {
+        boolean shouldUseParallelSplits = shouldUseParallelSplits(useParallelSplits, baseId, tableId, filterExpression, tableName);
+
+        if (shouldUseParallelSplits) {
             writeParallelPartitions(blockWriter, baseId, tableId, filterExpression, fieldTypeMappingJson,
                     queryLimit, hasOrderBy);
         }
@@ -754,6 +756,49 @@ public class BaseMetadataHandler
             writeSinglePartition(blockWriter, baseId, tableId, filterExpression, sortExpression,
                     fieldTypeMappingJson, queryLimit, useParallelSplits, hasOrderBy);
         }
+    }
+
+    /**
+     * Decides whether to actually use parallel splitting for this query, on top of whether the table
+     * structurally supports it ({@code tableHasParallelSplitKey}) and the feature is enabled.
+     * <p>
+     * Parallel splitting is planned using the table's FULL row count (see {@link #writeParallelPartitions}),
+     * because {@code $reserved_split_key} is a positional index over the whole table, not over filtered
+     * results - a selective filter can match rows anywhere in that key range, so splits must still cover it
+     * entirely to stay correct. That means a highly selective filter (e.g. {@code WHERE id = 'x'}) would
+     * otherwise spawn just as many splits as an unfiltered scan, with nearly all of them returning zero rows.
+     * When a filter is present, this checks its actual selectivity first: if the matching row count already
+     * fits in a single page, parallelizing has no benefit, so this returns false and the caller falls back to
+     * the single-partition path, which applies the filter correctly across the whole table via normal
+     * pagination without needing any positional range math.
+     *
+     * @param tableHasParallelSplitKey whether the table's schema has a {@code $reserved_split_key} column
+     * @param baseId the Lark Base ID
+     * @param tableId the Lark table ID
+     * @param filterExpression the translated filter for this query, or an empty string if there is none
+     * @param tableName used for logging only
+     * @return true if parallel splitting should be used for this query
+     */
+    @VisibleForTesting
+    protected boolean shouldUseParallelSplits(boolean tableHasParallelSplitKey, String baseId, String tableId,
+                                              String filterExpression, TableName tableName)
+    {
+        if (!tableHasParallelSplitKey || !envVarService.isActivateParallelSplit()) {
+            return false;
+        }
+
+        if (filterExpression == null || filterExpression.isEmpty()) {
+            return true;
+        }
+
+        int filteredRowCount = getTotalRowCount(baseId, tableId, filterExpression);
+        if (filteredRowCount <= PAGE_SIZE) {
+            logger.info("getPartitions: Filter for table {} matches only {} row(s), which fits in a single "
+                    + "page. Skipping parallel split planning in favor of a single partition.", tableName, filteredRowCount);
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseRecordHandler.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseRecordHandler.java
@@ -103,7 +103,7 @@ public class BaseRecordHandler extends RecordHandler
         super(SOURCE_TYPE, configOptions);
         ThrottlingInvoker invoker = ThrottlingInvoker.newDefaultBuilder(EXCEPTION_FILTER, configOptions).build();
         this.envVarService = new EnvVarService(configOptions, invoker);
-        this.larkBaseService = new LarkBaseService(envVarService.getLarkAppId(), envVarService.getLarkAppSecret());
+        this.larkBaseService = new LarkBaseService(envVarService.getLarkAppId(), envVarService.getLarkAppSecret(), envVarService.getLookupMaxDepth());
         this.invokerCache = CacheBuilder.newBuilder().build(
                 new CacheLoader<>()
                 {

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/metadataProvider/ExperimentalMetadataProvider.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/metadataProvider/ExperimentalMetadataProvider.java
@@ -86,19 +86,31 @@ public class ExperimentalMetadataProvider
                     String larkFieldName = field.getFieldName();
                     if (larkFieldName != null && !larkFieldName.trim().isEmpty()) {
                         logger.info("Experimental Path: Processing field: {}", larkFieldName);
-                        UITypeEnum childUIType = field.getFormulaGlueCatalogUITypeEnum();
-
-                        if (childUIType.equals(UITypeEnum.LOOKUP)) {
+                        // NOTE: getFormulaGlueCatalogUITypeEnum() only returns a meaningful (non-UNKNOWN) value
+                        // when the field's own UI type is FORMULA, while getTargetFieldAndTableForLookup() only
+                        // returns a usable target when the field's own UI type is LOOKUP. A field cannot be both
+                        // at once, so checking the former for LOOKUP and then calling the latter was dead code -
+                        // a genuine LOOKUP field's child type could never actually be resolved this way. Branch
+                        // on the field's own UI type instead, matching the (correct) logic in
+                        // glue-lark-base-crawler's BaseLarkBaseCrawlerHandler.
+                        UITypeEnum childUIType;
+                        if (field.getUIType().equals(UITypeEnum.LOOKUP)) {
                             try {
                                 Pair<String, String> lookupId = field.getTargetFieldAndTableForLookup();
                                 String newTableId = lookupId.right();
                                 String newFieldId = lookupId.left();
-                                childUIType = larkBaseService.getLookupType(baseId, newTableId, newFieldId);
+                                // getTableFields (called internally by getLookupType on a cache miss) hits the
+                                // Lark API directly; go through the invoker like every other Lark call here so
+                                // it gets the same rate-limit backoff instead of failing raw on a 429.
+                                childUIType = invoker.invoke(() -> larkBaseService.getLookupType(baseId, newTableId, newFieldId));
                             }
                             catch (Exception e) {
                                 logger.warn("Experimental Path: Skipping field {} due to error getting lookup type: {}", field.getFieldName(), e.getMessage());
                                 continue;
                             }
+                        }
+                        else {
+                            childUIType = field.getFormulaGlueCatalogUITypeEnum();
                         }
 
                         NestedUIType nestedUIType = new NestedUIType(field.getUIType(), childUIType);
@@ -200,19 +212,26 @@ public class ExperimentalMetadataProvider
                 String larkFieldName = field.getFieldName();
                 if (larkFieldName != null && !larkFieldName.trim().isEmpty()) {
                     String prestoFieldName = CommonUtil.sanitizeGlueRelatedName(larkFieldName);
-                    UITypeEnum childUIType = field.getFormulaGlueCatalogUITypeEnum();
-
-                    if (childUIType.equals(UITypeEnum.LOOKUP)) {
+                    // See the comment in getTableSchema(): branch on the field's own UI type, not
+                    // getFormulaGlueCatalogUITypeEnum(), which can never actually equal LOOKUP for a genuine
+                    // LOOKUP field and would otherwise leave the child type unresolved (dead code).
+                    UITypeEnum childUIType;
+                    if (field.getUIType().equals(UITypeEnum.LOOKUP)) {
                         try {
                             Pair<String, String> lookupId = field.getTargetFieldAndTableForLookup();
                             String newTableId = lookupId.right();
                             String newFieldId = lookupId.left();
-                            childUIType = larkBaseService.getLookupType(larkBaseId, newTableId, newFieldId);
+                            // See the comment on the equivalent call in getTableSchema(): route through the
+                            // invoker so a cache-miss fetch inside getLookupType gets rate-limit backoff too.
+                            childUIType = invoker.invoke(() -> larkBaseService.getLookupType(larkBaseId, newTableId, newFieldId));
                         }
                         catch (Exception e) {
                             logger.warn("Experimental Path: Skipping field {} due to error getting lookup type: {}", field.getFieldName(), e.getMessage());
                             continue;
                         }
+                    }
+                    else {
+                        childUIType = field.getFormulaGlueCatalogUITypeEnum();
                     }
 
                     NestedUIType nestedUIType = new NestedUIType(field.getUIType(), childUIType);

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/model/response/ListFieldResponse.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/model/response/ListFieldResponse.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.utils.Pair;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.amazonaws.athena.connectors.lark.base.model.enums.UITypeEnum.BUTTON;
 import static com.amazonaws.athena.connectors.lark.base.model.enums.UITypeEnum.STAGE;
@@ -84,7 +85,16 @@ public final class ListFieldResponse extends BaseResponse<ListFieldResponse.List
         {
             this.fieldId = builder.fieldId;
             this.fieldName = builder.fieldName;
-            this.property = builder.property != null ? Map.copyOf(builder.property) : Collections.emptyMap();
+            // Ensure immutable map, filter out null values (Lark returns null for unset properties)
+            if (builder.property != null) {
+                Map<String, Object> nonNullProperty = builder.property.entrySet().stream()
+                        .filter(e -> e.getValue() != null)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                this.property = Map.copyOf(nonNullProperty);
+            }
+            else {
+                this.property = Collections.emptyMap();
+            }
             this.description = builder.description;
             this.isPrimary = builder.isPrimary;
             this.required = builder.required;

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/resolver/LarkBaseTableResolver.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/resolver/LarkBaseTableResolver.java
@@ -216,13 +216,23 @@ public class LarkBaseTableResolver
                 String larkFieldName = field.getFieldName();
                 if (isValidIdentifier(larkFieldName)) {
                     String prestoFieldName = CommonUtil.sanitizeGlueRelatedName(larkFieldName);
-                    UITypeEnum childUIType = field.getFormulaGlueCatalogUITypeEnum();
-
-                    if (childUIType.equals(UITypeEnum.LOOKUP)) {
+                    // NOTE: getFormulaGlueCatalogUITypeEnum() only returns a meaningful (non-UNKNOWN) value when
+                    // the field's own UI type is FORMULA, while getTargetFieldAndTableForLookup() only returns a
+                    // usable target when the field's own UI type is LOOKUP. A field cannot be both at once, so
+                    // checking the former for LOOKUP and then calling the latter was dead code - a genuine LOOKUP
+                    // field's child type could never actually be resolved this way. Branch on the field's own UI
+                    // type instead, matching the (correct) logic in glue-lark-base-crawler's BaseLarkBaseCrawlerHandler.
+                    UITypeEnum childUIType;
+                    if (field.getUIType().equals(UITypeEnum.LOOKUP)) {
                         Pair<String, String> lookupId = field.getTargetFieldAndTableForLookup();
                         String newTableId = lookupId.right();
                         String newFieldId = lookupId.left();
-                        childUIType = larkBaseService.getLookupType(larkBaseId, newTableId, newFieldId);
+                        // Route through the invoker so a cache-miss fetch inside getLookupType gets the same
+                        // rate-limit backoff as every other Lark API call here.
+                        childUIType = invoker.invoke(() -> larkBaseService.getLookupType(larkBaseId, newTableId, newFieldId));
+                    }
+                    else {
+                        childUIType = field.getFormulaGlueCatalogUITypeEnum();
                     }
 
                     NestedUIType nestedUIType = new NestedUIType(field.getUIType(), childUIType);

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/service/EnvVarService.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/service/EnvVarService.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DEFAULT_LARK_LOOKUP_MAX_DEPTH;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DOES_ACTIVATE_EXPERIMENTAL_FEATURE_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DOES_ACTIVATE_LARK_BASE_SOURCE_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DOES_ACTIVATE_LARK_DRIVE_SOURCE_ENV_VAR;
@@ -37,6 +38,7 @@ import static com.amazonaws.athena.connectors.lark.base.BaseConstants.ENABLE_DEB
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_APP_KEY_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_BASE_SOURCES_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_DRIVE_SOURCES_ENV_VAR;
+import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_LOOKUP_MAX_DEPTH_ENV_VAR;
 import static java.util.Objects.requireNonNull;
 
 public class EnvVarService
@@ -53,6 +55,7 @@ public class EnvVarService
     private final boolean enableDebugLogging;
     private final String larkBaseSources;
     private final String larkDriveSources;
+    private final int lookupMaxDepth;
 
     public EnvVarService(Map<String, String> configOptions, ThrottlingInvoker invoker)
     {
@@ -91,6 +94,21 @@ public class EnvVarService
         this.enableDebugLogging = Boolean.parseBoolean(configOptions.getOrDefault(ENABLE_DEBUG_LOGGING_ENV_VAR, "false"));
         this.larkBaseSources = configOptions.getOrDefault(LARK_BASE_SOURCES_ENV_VAR, "");
         this.larkDriveSources = configOptions.getOrDefault(LARK_DRIVE_SOURCES_ENV_VAR, "");
+        this.lookupMaxDepth = parseLookupMaxDepth(configOptions.get(LARK_LOOKUP_MAX_DEPTH_ENV_VAR));
+    }
+
+    private static int parseLookupMaxDepth(String rawValue)
+    {
+        if (rawValue == null || rawValue.isEmpty()) {
+            return DEFAULT_LARK_LOOKUP_MAX_DEPTH;
+        }
+        try {
+            int parsed = Integer.parseInt(rawValue);
+            return parsed > 0 ? parsed : DEFAULT_LARK_LOOKUP_MAX_DEPTH;
+        }
+        catch (NumberFormatException e) {
+            return DEFAULT_LARK_LOOKUP_MAX_DEPTH;
+        }
     }
 
     public String getLarkAppId()
@@ -136,5 +154,10 @@ public class EnvVarService
     public String getLarkDriveSources()
     {
         return larkDriveSources;
+    }
+
+    public int getLookupMaxDepth()
+    {
+        return lookupMaxDepth;
     }
 }

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/service/LarkBaseService.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/service/LarkBaseService.java
@@ -46,10 +46,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DEFAULT_LARK_LOOKUP_MAX_DEPTH;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.PAGE_SIZE;
 import static java.util.Objects.requireNonNull;
 
@@ -65,31 +68,36 @@ public class LarkBaseService extends CommonLarkService
     // Cache table fields to avoid N+1 query problem when resolving lookup types
     private final LoadingCache<String, List<ListFieldResponse.FieldItem>> tableFieldsCache;
 
+    // Safety valve on top of cycle detection for chained LOOKUP resolution; see BaseConstants.LARK_LOOKUP_MAX_DEPTH_ENV_VAR.
+    private final int lookupMaxDepth;
+
     public LarkBaseService(String larkAppId, String larkAppSecret)
     {
+        this(larkAppId, larkAppSecret, DEFAULT_LARK_LOOKUP_MAX_DEPTH);
+    }
+
+    public LarkBaseService(String larkAppId, String larkAppSecret, int lookupMaxDepth)
+    {
         super(larkAppId, larkAppSecret);
-        this.tableFieldsCache = CacheBuilder.newBuilder()
-                .maximumSize(FIELD_CACHE_MAX_SIZE)
-                .expireAfterWrite(FIELD_CACHE_TTL_MINUTES, TimeUnit.MINUTES)
-                .build(new CacheLoader<String, List<ListFieldResponse.FieldItem>>()
-                {
-                    @Override
-                    @Nonnull
-                    public List<ListFieldResponse.FieldItem> load(@Nonnull String tableKey) throws Exception
-                    {
-                        String[] parts = tableKey.split("\\|");
-                        if (parts.length != 2) {
-                            throw new IllegalArgumentException("Invalid table key format: " + tableKey);
-                        }
-                        return fetchTableFieldsUncached(parts[0], parts[1]);
-                    }
-                });
+        this.lookupMaxDepth = lookupMaxDepth;
+        this.tableFieldsCache = buildTableFieldsCache();
     }
 
     public LarkBaseService(String larkAppId, String larkAppSecret, HttpClientWrapper httpClient)
     {
+        this(larkAppId, larkAppSecret, httpClient, DEFAULT_LARK_LOOKUP_MAX_DEPTH);
+    }
+
+    public LarkBaseService(String larkAppId, String larkAppSecret, HttpClientWrapper httpClient, int lookupMaxDepth)
+    {
         super(larkAppId, larkAppSecret, httpClient);
-        this.tableFieldsCache = CacheBuilder.newBuilder()
+        this.lookupMaxDepth = lookupMaxDepth;
+        this.tableFieldsCache = buildTableFieldsCache();
+    }
+
+    private LoadingCache<String, List<ListFieldResponse.FieldItem>> buildTableFieldsCache()
+    {
+        return CacheBuilder.newBuilder()
                 .maximumSize(FIELD_CACHE_MAX_SIZE)
                 .expireAfterWrite(FIELD_CACHE_TTL_MINUTES, TimeUnit.MINUTES)
                 .build(new CacheLoader<String, List<ListFieldResponse.FieldItem>>()
@@ -414,6 +422,35 @@ public class LarkBaseService extends CommonLarkService
 
     public UITypeEnum getLookupType(String baseId, String tableId, String fieldId)
     {
+        return getLookupType(baseId, tableId, fieldId, new HashSet<>());
+    }
+
+    /**
+     * Resolves the effective UI type of a (possibly chained) LOOKUP field, following each LOOKUP to its target
+     * field/table until a non-LOOKUP type is found.
+     *
+     * @param visited table/field pairs already visited in this resolution chain. A misconfigured Lark Base can
+     *                have LOOKUP fields that reference each other in a cycle (e.g. table A's field looks up to
+     *                table B's field, which looks up back to table A's field); without cycle detection this would
+     *                recurse indefinitely and crash schema discovery with a StackOverflowError. On top of that,
+     *                {@code lookupMaxDepth} (configurable via {@code LARK_LOOKUP_MAX_DEPTH_ENV_VAR}) caps how many
+     *                hops are followed even for a legitimate, non-circular chain, as a defense-in-depth safety valve.
+     */
+    private UITypeEnum getLookupType(String baseId, String tableId, String fieldId, Set<String> visited)
+    {
+        if (visited.size() >= lookupMaxDepth) {
+            logger.warn("LOOKUP resolution for field '{}' in table '{}' (base '{}') exceeded the configured max "
+                    + "depth ({}). Returning UNKNOWN.", fieldId, tableId, baseId, lookupMaxDepth);
+            return UITypeEnum.UNKNOWN;
+        }
+
+        String visitKey = tableId + "|" + fieldId;
+        if (!visited.add(visitKey)) {
+            logger.warn("Detected circular LOOKUP reference while resolving field '{}' in table '{}' (base '{}'). "
+                    + "Breaking the cycle and returning UNKNOWN.", fieldId, tableId, baseId);
+            return UITypeEnum.UNKNOWN;
+        }
+
         List<ListFieldResponse.FieldItem> fields = getTableFields(baseId, tableId);
         for (ListFieldResponse.FieldItem field : fields) {
             if (field.getFieldId().equalsIgnoreCase(fieldId)) {
@@ -421,7 +458,7 @@ public class LarkBaseService extends CommonLarkService
                     Pair<String, String> lookupId = field.getTargetFieldAndTableForLookup();
                     String newTableId = lookupId.right();
                     String newFieldId = lookupId.left();
-                    return getLookupType(baseId, newTableId, newFieldId);
+                    return getLookupType(baseId, newTableId, newFieldId, visited);
                 }
 
                 return field.getUIType();

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractor.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractor.java
@@ -296,17 +296,26 @@ public class RegistererExtractor
                     Object textVal = mapElement.get("text");
                     outputValue = (textVal != null) ? String.valueOf(textVal) : null;
                 }
-                // Handle TEXT fields: [{text: "...", type: "text"}] (list of maps)
+                // Handle TEXT fields with multiple segments: [{text: "...", type: "text"}, {text: "...", type: "mention", ...}, ...]
+                // Lark splits a cell into several segments when the text contains @mentions or links mixed with
+                // plain text. Every segment (text or mention) carries a "text" key with its display value, so all
+                // segments must be concatenated - otherwise everything after the first segment is silently dropped.
                 else if (unwrappedValue instanceof List<?> listVal && !listVal.isEmpty()) {
-                    Object firstElement = listVal.get(0);
-                    if (firstElement instanceof Map<?, ?> mapElement && mapElement.containsKey("text")) {
-                        Object textVal = mapElement.get("text");
-                        outputValue = (textVal != null) ? String.valueOf(textVal) : null;
+                    StringBuilder segmentsBuilder = new StringBuilder();
+                    for (Object element : listVal) {
+                        if (element instanceof Map<?, ?> mapElement && mapElement.containsKey("text")) {
+                            Object textVal = mapElement.get("text");
+                            if (textVal != null) {
+                                segmentsBuilder.append(textVal);
+                            }
+                        }
+                        else {
+                            segmentsBuilder.append(String.valueOf(element));
+                        }
                     }
-                    else {
-                        // Fallback to first element as string
-                        outputValue = String.valueOf(firstElement);
-                    }
+                    // Fall back to the raw list representation only if every segment yielded nothing
+                    // (e.g. a single segment with a null "text" value), matching the single-map fallback below.
+                    outputValue = (segmentsBuilder.length() > 0) ? segmentsBuilder.toString() : null;
                 }
 
                 if (outputValue == null) {
@@ -319,7 +328,7 @@ public class RegistererExtractor
                 }
             }
             catch (Exception e) {
-                logger.error("VarCharExtractor: Error untuk field '{}', nilai mentah tipe {}: {}. Nilai: {}",
+                logger.error("VarCharExtractor: Error for field '{}', raw value type {}: {}. Value: {}",
                         athenaFieldName, rawValue.getClass().getName(), e.getMessage(), rawValue, e);
                 dst.isSet = 0;
             }

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslator.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslator.java
@@ -69,6 +69,7 @@ public final class SearchApiFilterTranslator
         }
 
         List<Map<String, Object>> allConditions = new ArrayList<>();
+        List<Map<String, Object>> orGroups = new ArrayList<>();
 
         for (Map.Entry<String, ValueSet> entry : constraints.entrySet()) {
             String lowercaseColumnName = entry.getKey();
@@ -88,11 +89,28 @@ public final class SearchApiFilterTranslator
                 continue;
             }
 
-            List<Map<String, Object>> conditions = translateValueSetToConditions(fieldName, valueSet, fieldUiType);
-            allConditions.addAll(conditions);
+            // Lark's Search API restricts the "is"/"isNot" operators to a single value each (there is no native
+            // "in" operator - it is documented as not yet supported), so an IN-clause with more than one value
+            // cannot be expressed as multiple "is" conditions ANDed together - that would require the field to
+            // equal every value simultaneously and would always match zero rows. Instead, express it as an
+            // OR-group of single-value "is" conditions nested under the top-level AND via "children", which is
+            // the pattern Lark's filter guide recommends. A NOT IN-clause (blacklist) is unaffected: multiple
+            // "isNot" conditions ANDed together already correctly means "not equal to any of these values".
+            if (valueSet instanceof EquatableValueSet equatableValueSet
+                    && equatableValueSet.isWhiteList() && equatableValueSet.getValueBlock().getRowCount() > 1) {
+                List<Map<String, Object>> orConditions = translateEquatableValueSet(fieldName, equatableValueSet, fieldUiType);
+                Map<String, Object> orGroup = new HashMap<>();
+                orGroup.put("conjunction", "or");
+                orGroup.put("conditions", orConditions);
+                orGroups.add(orGroup);
+            }
+            else {
+                List<Map<String, Object>> conditions = translateValueSetToConditions(fieldName, valueSet, fieldUiType);
+                allConditions.addAll(conditions);
+            }
         }
 
-        if (allConditions.isEmpty()) {
+        if (allConditions.isEmpty() && orGroups.isEmpty()) {
             return "";
         }
 
@@ -100,6 +118,9 @@ public final class SearchApiFilterTranslator
         Map<String, Object> filter = new HashMap<>();
         filter.put("conjunction", "and");
         filter.put("conditions", allConditions);
+        if (!orGroups.isEmpty()) {
+            filter.put("children", orGroups);
+        }
 
         try {
             return OBJECT_MAPPER.writeValueAsString(filter);
@@ -375,6 +396,7 @@ public final class SearchApiFilterTranslator
 
         try {
             List<Map<String, Object>> allConditions = new ArrayList<>();
+            List<Map<String, Object>> existingChildren = null;
 
             // Parse existing filter if present
             if (existingFilterJson != null && !existingFilterJson.isBlank()) {
@@ -383,6 +405,9 @@ public final class SearchApiFilterTranslator
                 if (existingConditions != null) {
                     allConditions.addAll(existingConditions);
                 }
+                // IN-clause conditions are carried as OR-groups under "children" (see toFilterJson); they must be
+                // preserved here too, otherwise combining a split range with an IN-clause would silently drop it.
+                existingChildren = (List<Map<String, Object>>) existingFilter.get("children");
             }
 
             // Add split range conditions
@@ -403,6 +428,9 @@ public final class SearchApiFilterTranslator
             Map<String, Object> filter = new HashMap<>();
             filter.put("conjunction", "and");
             filter.put("conditions", allConditions);
+            if (existingChildren != null && !existingChildren.isEmpty()) {
+                filter.put("children", existingChildren);
+            }
 
             return OBJECT_MAPPER.writeValueAsString(filter);
         }

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtil.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtil.java
@@ -102,13 +102,23 @@ public final class CommonUtil
     private static UITypeEnum extractFormulaOrLookup(String raw)
     {
         // example: LarkBaseFieldType=Formula<FormulaType>
-        String[] parts = raw.split("<");
-        if (parts.length > 1) {
-            String formulaType = parts[1].replace(">", "");
-            return UITypeEnum.fromString(formulaType);
+        // A chained LOOKUP (one LOOKUP field pointing at another LOOKUP field) is written by the Glue Crawler
+        // as a nested string, e.g. "Lookup<Lookup<Number>>" (see BaseLarkBaseCrawlerHandler.getLarkBaseOriginalColumnType,
+        // which recurses when the LOOKUP target is itself a LOOKUP). Splitting on the FIRST '<' and taking
+        // index [1] only ever captures the immediate next level ("Lookup" here), not the terminal type
+        // ("Number") - losing the actual resolved type for any chain of depth >= 2. Extracting from the LAST
+        // '<' instead always yields the innermost/terminal type, regardless of nesting depth.
+        int lastOpenBracket = raw.lastIndexOf('<');
+        if (lastOpenBracket == -1 || lastOpenBracket == raw.length() - 1) {
+            return null;
         }
 
-        return null;
+        String innermostType = raw.substring(lastOpenBracket + 1).replace(">", "");
+        if (innermostType.isEmpty()) {
+            return null;
+        }
+
+        return UITypeEnum.fromString(innermostType);
     }
 
     /**

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/LarkBaseTypeUtils.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/LarkBaseTypeUtils.java
@@ -68,7 +68,11 @@ public final class LarkBaseTypeUtils
             case CHECKBOX -> Types.MinorType.BIT;
 
             // Glue: array<...> -> Arrow: LIST
-            case MULTI_SELECT, USER, GROUP_CHAT, ATTACHMENT, CREATED_USER, MODIFIED_USER -> Types.MinorType.LIST;
+            // LOOKUP is included here to match the Glue Crawler path (UITypeEnum.getGlueCatalogType), which maps
+            // LOOKUP to array<{target field's type}>. Without this, LOOKUP fell through to the default VARCHAR
+            // case below, discarding the resolved target type entirely (see getLarkListChildField for how the
+            // list's child element type is derived from nestedUIType().childType()).
+            case MULTI_SELECT, USER, GROUP_CHAT, ATTACHMENT, CREATED_USER, MODIFIED_USER, LOOKUP -> Types.MinorType.LIST;
 
             // Glue: struct<...> -> Arrow: STRUCT
             case URL, LOCATION, SINGLE_LINK, DUPLEX_LINK -> Types.MinorType.STRUCT;
@@ -139,8 +143,40 @@ public final class LarkBaseTypeUtils
                     Field.nullable("name", ArrowType.Utf8.INSTANCE)
             ));
 
-  
+            // Glue: array<{target field's type}> -> Arrow Child: derived from the resolved LOOKUP target type
+            // (nestedUIType().childType(), already resolved to a terminal, non-LOOKUP type by
+            // LarkBaseService.getLookupType, which follows chained LOOKUPs to their final target).
+            case LOOKUP -> Field.nullable("item", scalarArrowTypeForLookupTarget(larkField.nestedUIType().childType()));
+
             default -> Field.nullable("item", ArrowType.Utf8.INSTANCE);
+        };
+    }
+
+    /**
+     * Maps a LOOKUP field's resolved target UI type to a simple/scalar Arrow type, for use as the LOOKUP's
+     * LIST child element type. Mirrors the Glue Crawler path's fallback semantics (glue-lark-base-crawler's
+     * UITypeEnum.getGlueCatalogType), which resolves a LOOKUP target to its Glue type when the target is a
+     * simple scalar (e.g. "decimal", "boolean", "timestamp"), and otherwise falls back to a plain string.
+     *
+     * @param targetUiType The resolved (terminal) UI type of the field the LOOKUP points to, or null/UNKNOWN
+     *                     if it could not be resolved (e.g. a broken/circular reference or an API error).
+     * @return The Arrow type to use for the LOOKUP list's child element.
+     */
+    private static ArrowType scalarArrowTypeForLookupTarget(UITypeEnum targetUiType)
+    {
+        if (targetUiType == null) {
+            return ArrowType.Utf8.INSTANCE;
+        }
+
+        return switch (targetUiType) {
+            case NUMBER, PROGRESS, CURRENCY -> new ArrowType.Decimal(38, 18, 128);
+            case RATING -> Types.MinorType.TINYINT.getType();
+            case CHECKBOX -> ArrowType.Bool.INSTANCE;
+            case DATE_TIME, CREATED_TIME, MODIFIED_TIME -> new ArrowType.Timestamp(TimeUnit.MILLISECOND, "UTC");
+            // TEXT, BARCODE, SINGLE_SELECT, PHONE, AUTO_NUMBER, EMAIL, and any type not yet supported as a
+            // LOOKUP target (MULTI_SELECT, USER, ATTACHMENT, URL, LOCATION, LINK, UNKNOWN, ...) fall back to a
+            // plain string representation, matching the Glue Crawler path's "array<string>" fallback.
+            default -> ArrowType.Utf8.INSTANCE;
         };
     }
 

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/SearchApiResponseNormalizer.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/SearchApiResponseNormalizer.java
@@ -135,7 +135,9 @@ public final class SearchApiResponseNormalizer
                         return textValue;
                     }
 
-                    // Multiple items: keep as array (for FORMULA, LOOKUP fields)
+                    // Multiple items: keep as array. This happens for FORMULA/LOOKUP fields, and also for plain
+                    // TEXT fields whose content mixes @mentions or links with regular text - each segment must
+                    // reach RegistererExtractor so it can reconstruct the full text instead of using only one segment.
                     logger.debug("Keeping array format for field '{}' with {} items", fieldName, listValue.size());
                     return value;
                 }

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandlerTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandlerTest.java
@@ -28,6 +28,7 @@ import com.amazonaws.athena.connector.lambda.security.LocalKeyFactory;
 import com.amazonaws.athena.connectors.lark.base.metadataProvider.ExperimentalMetadataProvider;
 import com.amazonaws.athena.connectors.lark.base.metadataProvider.LarkSourceMetadataProvider;
 import com.amazonaws.athena.connectors.lark.base.model.TableDirectInitialized;
+import com.amazonaws.athena.connectors.lark.base.model.response.ListRecordsResponse;
 import com.amazonaws.athena.connectors.lark.base.service.EnvVarService;
 import com.amazonaws.athena.connectors.lark.base.service.GlueCatalogService;
 import com.amazonaws.athena.connectors.lark.base.service.LarkBaseService;
@@ -174,5 +175,82 @@ public class BaseMetadataHandlerTest {
         assertNotNull(response);
         assertEquals("test-catalog", response.getCatalogName());
         assertTrue(response.getSplits().isEmpty());
+    }
+
+    @Test
+    public void testShouldUseParallelSplits_falseWhenTableHasNoParallelSplitKey() {
+        com.amazonaws.athena.connector.lambda.domain.TableName tableName =
+            new com.amazonaws.athena.connector.lambda.domain.TableName("test_schema", "test_table");
+
+        // Absence of the split key must short-circuit before even checking the activation flag.
+        boolean result = handler.shouldUseParallelSplits(false, "base1", "tbl1", "", tableName);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testShouldUseParallelSplits_falseWhenFeatureNotActivated() {
+        com.amazonaws.athena.connector.lambda.domain.TableName tableName =
+            new com.amazonaws.athena.connector.lambda.domain.TableName("test_schema", "test_table");
+        when(mockEnvVarService.isActivateParallelSplit()).thenReturn(false);
+
+        boolean result = handler.shouldUseParallelSplits(true, "base1", "tbl1", "", tableName);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testShouldUseParallelSplits_trueWhenNoFilter() throws Exception {
+        com.amazonaws.athena.connector.lambda.domain.TableName tableName =
+            new com.amazonaws.athena.connector.lambda.domain.TableName("test_schema", "test_table");
+        when(mockEnvVarService.isActivateParallelSplit()).thenReturn(true);
+
+        boolean result = handler.shouldUseParallelSplits(true, "base1", "tbl1", "", tableName);
+
+        assertTrue(result);
+        // No filter means no selectivity check is needed, so the row-count lookup must never fire.
+        verify(mockInvoker, never()).invoke(any());
+    }
+
+    @Test
+    public void testShouldUseParallelSplits_falseWhenFilterIsHighlySelective() throws Exception {
+        // A selective filter (e.g. WHERE id = 'x') matching only a handful of rows must not trigger parallel
+        // splitting, because splits are sized off the table's full row count and would mostly return zero rows.
+        com.amazonaws.athena.connector.lambda.domain.TableName tableName =
+            new com.amazonaws.athena.connector.lambda.domain.TableName("test_schema", "test_table");
+        when(mockEnvVarService.isActivateParallelSplit()).thenReturn(true);
+
+        ListRecordsResponse response = (ListRecordsResponse) ListRecordsResponse.builder()
+                .data(ListRecordsResponse.ListData.builder()
+                        .items(Collections.emptyList())
+                        .hasMore(false)
+                        .total(1)
+                        .build())
+                .build();
+        when(mockInvoker.invoke(any())).thenReturn(response);
+
+        boolean result = handler.shouldUseParallelSplits(true, "base1", "tbl1", "{\"conditions\":[]}", tableName);
+
+        assertFalse(result);
+    }
+
+    @Test
+    public void testShouldUseParallelSplits_trueWhenFilterMatchesManyRows() throws Exception {
+        com.amazonaws.athena.connector.lambda.domain.TableName tableName =
+            new com.amazonaws.athena.connector.lambda.domain.TableName("test_schema", "test_table");
+        when(mockEnvVarService.isActivateParallelSplit()).thenReturn(true);
+
+        ListRecordsResponse response = (ListRecordsResponse) ListRecordsResponse.builder()
+                .data(ListRecordsResponse.ListData.builder()
+                        .items(Collections.emptyList())
+                        .hasMore(false)
+                        .total(50_000)
+                        .build())
+                .build();
+        when(mockInvoker.invoke(any())).thenReturn(response);
+
+        boolean result = handler.shouldUseParallelSplits(true, "base1", "tbl1", "{\"conditions\":[]}", tableName);
+
+        assertTrue(result);
     }
 }

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/metadataProvider/ExperimentalMetadataProviderTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/metadataProvider/ExperimentalMetadataProviderTest.java
@@ -50,6 +50,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class ExperimentalMetadataProviderTest {
@@ -254,6 +255,8 @@ public class ExperimentalMetadataProviderTest {
 
         assertTrue(result.isPresent());
         assertEquals(1, result.get().fieldNameMappings().size());
+        // The chained LOOKUP must actually resolve to its target field's type (TEXT), not be left null/UNKNOWN.
+        assertEquals(UITypeEnum.TEXT, result.get().fieldNameMappings().get(0).nestedUIType().childType());
     }
 
     @Test
@@ -327,8 +330,12 @@ public class ExperimentalMetadataProviderTest {
 
         Optional<TableSchemaResult> result = metadataProvider.getTableSchema(request);
 
-        assertTrue(result.isPresent());
-        assertEquals(1, result.get().schema().getFields().size());
+        // The only field is a LOOKUP whose type resolution throws, so it is skipped (see the catch+continue in
+        // getTableSchema). With no fields left, the schema is empty, not the pre-fix behavior of silently
+        // including it with an unresolved type - that only "worked" because getLookupType was never actually
+        // reached due to the (now fixed) dead-code bug in the LOOKUP-vs-FORMULA branch condition.
+        assertFalse(result.isPresent());
+        verify(larkBaseService).getLookupType("base1", "tblxxxx", "fldxxxx");
     }
 
     @Test
@@ -360,8 +367,10 @@ public class ExperimentalMetadataProviderTest {
 
         Optional<PartitionInfoResult> result = metadataProvider.getPartitionInfo(new TableName("base1", "table1"), request);
 
-        assertTrue(result.isPresent());
-        assertEquals(1, result.get().fieldNameMappings().size());
+        // Same reasoning as getTableSchema_lookupTypeThrowsException: the only field is a LOOKUP whose type
+        // resolution throws, so it's skipped (catch+continue), leaving no field mappings and an empty Optional.
+        assertFalse(result.isPresent());
+        verify(larkBaseService).getLookupType("base1", "tblxxxx", "fldxxxx");
     }
 
     @Test

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/model/response/ListFieldResponseTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/model/response/ListFieldResponseTest.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.utils.Pair;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -69,6 +70,22 @@ class ListFieldResponseTest {
         // Assert
         assertThat(item.getFieldId()).isEqualTo("fld1");
         assertThat(item.getUIType()).isEqualTo(UITypeEnum.NUMBER);
+    }
+
+    @Test
+    void testFieldItemProperty_whenValuesAreNull_shouldNotThrowAndStillResolve() {
+        Map<String, Object> propertyWithNull = new HashMap<>();
+        propertyWithNull.put("type", Map.of("ui_type", "Number"));
+        propertyWithNull.put("unset_config", null);
+
+        ListFieldResponse.FieldItem item = ListFieldResponse.FieldItem.builder()
+                .fieldId("fld1")
+                .fieldName("Formula Field")
+                .uiType("Formula")
+                .property(propertyWithNull)
+                .build();
+
+        assertThat(item.getFormulaGlueCatalogUITypeEnum()).isEqualTo(UITypeEnum.NUMBER);
     }
 
     @Test

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/resolver/LarkBaseTableResolverTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/resolver/LarkBaseTableResolverTest.java
@@ -46,6 +46,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class LarkBaseTableResolverTest {
@@ -150,12 +152,25 @@ public class LarkBaseTableResolverTest {
                 .build();
 
         when(mockLarkBaseService.getTableFields(anyString(), anyString())).thenReturn(Collections.singletonList(lookupField));
-        when(mockLarkBaseService.getLookupType("base1", "relatedTableId", "relatedFieldId")).thenReturn(UITypeEnum.TEXT);
+        // The LOOKUP is resolved using the Lark base ID ("db1", from LarkDatabaseRecord.id()), not the
+        // Athena/Presto database name ("base1", from LarkDatabaseRecord.name()) - discoverTableFields is called
+        // with larkBaseId, which comes from record.id() in processTargetDatabaseRecords.
+        when(mockLarkBaseService.getLookupType("db1", "relatedTableId", "relatedFieldId")).thenReturn(UITypeEnum.TEXT);
 
         List<TableDirectInitialized> tables = resolver.resolveTables();
         assertEquals(1, tables.size());
         assertEquals(1, tables.get(0).columns().size());
         assertEquals("lookupField", tables.get(0).columns().get(0).larkBaseFieldName());
+        // The chained LOOKUP must actually resolve to its target field's type (TEXT), not be left null/UNKNOWN.
+        assertEquals(UITypeEnum.TEXT, tables.get(0).columns().get(0).nestedUIType().childType());
+
+        // getLookupType() itself calls getTableFields() internally on a cache miss, hitting the Lark API
+        // directly; it must go through the same throttling invoker as every other Lark API call in this
+        // resolver so a 429 gets rate-limit backoff instead of failing raw. The lookup call must be routed
+        // through invoker.invoke(...) (4 calls total: getDatabaseRecords, listTables, getTableFields for
+        // table1, and the LOOKUP resolution), not called directly and unwrapped.
+        verify(mockLarkBaseService).getLookupType("db1", "relatedTableId", "relatedFieldId");
+        verify(mockInvoker, times(4)).invoke(any(Callable.class));
     }
 
     @Test

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/service/EnvVarServiceTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/service/EnvVarServiceTest.java
@@ -98,6 +98,7 @@ public class EnvVarServiceTest {
         configOptions.put(ENABLE_DEBUG_LOGGING_ENV_VAR, "true");
         configOptions.put(LARK_BASE_SOURCES_ENV_VAR, "base1,base2");
         configOptions.put(LARK_DRIVE_SOURCES_ENV_VAR, "drive1,drive2");
+        configOptions.put(LARK_LOOKUP_MAX_DEPTH_ENV_VAR, "5");
 
         SecretValue secretValue = new SecretValue("test_app_id", "test_app_secret");
         String secretJson = objectMapper.writeValueAsString(secretValue);
@@ -114,5 +115,42 @@ public class EnvVarServiceTest {
         assertTrue(envVarService.isEnableDebugLogging());
         assertEquals("base1,base2", envVarService.getLarkBaseSources());
         assertEquals("drive1,drive2", envVarService.getLarkDriveSources());
+        assertEquals(5, envVarService.getLookupMaxDepth());
+    }
+
+    @Test
+    public void getLookupMaxDepth_whenUnset_usesDefault() throws Exception {
+        Map<String, String> configOptions = new HashMap<>();
+        configOptions.put(LARK_APP_KEY_ENV_VAR, "test_secret");
+
+        SecretValue secretValue = new SecretValue("test_app_id", "test_app_secret");
+        String secretJson = objectMapper.writeValueAsString(secretValue);
+
+        ThrottlingInvoker invoker = Mockito.mock(ThrottlingInvoker.class);
+        when(invoker.invoke(any())).thenReturn(secretJson);
+
+        EnvVarService envVarService = new EnvVarService(configOptions, invoker);
+
+        assertEquals(DEFAULT_LARK_LOOKUP_MAX_DEPTH, envVarService.getLookupMaxDepth());
+    }
+
+    @Test
+    public void getLookupMaxDepth_whenInvalidOrNonPositive_usesDefault() throws Exception {
+        SecretValue secretValue = new SecretValue("test_app_id", "test_app_secret");
+        String secretJson = objectMapper.writeValueAsString(secretValue);
+
+        for (String invalidValue : new String[] {"not_a_number", "0", "-5", ""}) {
+            Map<String, String> configOptions = new HashMap<>();
+            configOptions.put(LARK_APP_KEY_ENV_VAR, "test_secret");
+            configOptions.put(LARK_LOOKUP_MAX_DEPTH_ENV_VAR, invalidValue);
+
+            ThrottlingInvoker invoker = Mockito.mock(ThrottlingInvoker.class);
+            when(invoker.invoke(any())).thenReturn(secretJson);
+
+            EnvVarService envVarService = new EnvVarService(configOptions, invoker);
+
+            assertEquals(DEFAULT_LARK_LOOKUP_MAX_DEPTH, envVarService.getLookupMaxDepth(),
+                    "Expected default for invalid value: '" + invalidValue + "'");
+        }
     }
 }

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/service/LarkBaseServiceTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/service/LarkBaseServiceTest.java
@@ -334,6 +334,81 @@ public class LarkBaseServiceTest {
     }
 
     @Test
+    public void getLookupType_multiHopChain_resolvesThroughSeveralTables() throws Exception {
+        // tbl1.fld1 -> looks up tbl2.fld2 -> looks up tbl3.fld3 (Text)
+        String baseId = "base1";
+
+        String mockJsonResponse1 = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld1\",\"field_name\":\"Field 1\",\"ui_type\":\"Lookup\", \"property\":{\"target_field\":\"fld2\",\"filter_info\":{\"target_table\":\"tbl2\"}}}]}}";
+        String mockJsonResponse2 = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld2\",\"field_name\":\"Field 2\",\"ui_type\":\"Lookup\", \"property\":{\"target_field\":\"fld3\",\"filter_info\":{\"target_table\":\"tbl3\"}}}]}}";
+        String mockJsonResponse3 = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld3\",\"field_name\":\"Field 3\",\"ui_type\":\"Text\"}],\"has_more\":false}}";
+
+        MockHttpClientWrapper mockHttpClient = new MockHttpClientWrapper();
+        mockHttpClient.addResponse(mockJsonResponse1, 200, "OK");
+        mockHttpClient.addResponse(mockJsonResponse2, 200, "OK");
+        mockHttpClient.addResponse(mockJsonResponse3, 200, "OK");
+        LarkBaseService larkBaseService = new LarkBaseService(TEST_APP_ID, TEST_APP_SECRET, mockHttpClient);
+
+        UITypeEnum result = larkBaseService.getLookupType(baseId, "tbl1", "fld1");
+
+        assertEquals(UITypeEnum.TEXT, result);
+    }
+
+    @Test
+    public void getLookupType_directSelfReference_breaksLoopAndReturnsUnknown() throws Exception {
+        // tbl1.fld1 is a LOOKUP that (misconfigured) points back at itself.
+        String baseId = "base1";
+        String mockJsonResponse = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld1\",\"field_name\":\"Field 1\",\"ui_type\":\"Lookup\", \"property\":{\"target_field\":\"fld1\",\"filter_info\":{\"target_table\":\"tbl1\"}}}]}}";
+
+        MockHttpClientWrapper mockHttpClient = new MockHttpClientWrapper();
+        mockHttpClient.addResponse(mockJsonResponse, 200, "OK");
+        LarkBaseService larkBaseService = new LarkBaseService(TEST_APP_ID, TEST_APP_SECRET, mockHttpClient);
+
+        UITypeEnum result = larkBaseService.getLookupType(baseId, "tbl1", "fld1");
+
+        assertEquals(UITypeEnum.UNKNOWN, result);
+    }
+
+    @Test
+    public void getLookupType_circularReferenceAcrossTwoTables_breaksLoopAndReturnsUnknown() throws Exception {
+        // tbl1.fld1 looks up tbl2.fld2, which looks up back to tbl1.fld1 - a cycle spanning two tables.
+        // Without cycle detection this recurses forever (using cached field data, so no extra HTTP calls are
+        // even needed to keep looping) and crashes schema discovery with a StackOverflowError.
+        String baseId = "base1";
+
+        String mockJsonResponse1 = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld1\",\"field_name\":\"Field 1\",\"ui_type\":\"Lookup\", \"property\":{\"target_field\":\"fld2\",\"filter_info\":{\"target_table\":\"tbl2\"}}}]}}";
+        String mockJsonResponse2 = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld2\",\"field_name\":\"Field 2\",\"ui_type\":\"Lookup\", \"property\":{\"target_field\":\"fld1\",\"filter_info\":{\"target_table\":\"tbl1\"}}}]}}";
+
+        MockHttpClientWrapper mockHttpClient = new MockHttpClientWrapper();
+        mockHttpClient.addResponse(mockJsonResponse1, 200, "OK");
+        mockHttpClient.addResponse(mockJsonResponse2, 200, "OK");
+        LarkBaseService larkBaseService = new LarkBaseService(TEST_APP_ID, TEST_APP_SECRET, mockHttpClient);
+
+        UITypeEnum result = larkBaseService.getLookupType(baseId, "tbl1", "fld1");
+
+        assertEquals(UITypeEnum.UNKNOWN, result);
+    }
+
+    @Test
+    public void getLookupType_configuredMaxDepth_cutsOffLegitimateChainBeforeCycleWouldTrigger() throws Exception {
+        // tbl1.fld1 -> tbl2.fld2 -> tbl3.fld3 (Text) is a legitimate, non-circular 3-hop chain. With the
+        // configurable max depth set to 2, resolution must stop after the 2nd hop and return UNKNOWN without
+        // ever fetching tbl3 - proving the constructor-supplied max depth (not just the default) is honored.
+        String baseId = "base1";
+
+        String mockJsonResponse1 = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld1\",\"field_name\":\"Field 1\",\"ui_type\":\"Lookup\", \"property\":{\"target_field\":\"fld2\",\"filter_info\":{\"target_table\":\"tbl2\"}}}]}}";
+        String mockJsonResponse2 = "{\"code\":0, \"data\":{\"items\":[{\"field_id\":\"fld2\",\"field_name\":\"Field 2\",\"ui_type\":\"Lookup\", \"property\":{\"target_field\":\"fld3\",\"filter_info\":{\"target_table\":\"tbl3\"}}}]}}";
+
+        MockHttpClientWrapper mockHttpClient = new MockHttpClientWrapper();
+        mockHttpClient.addResponse(mockJsonResponse1, 200, "OK");
+        mockHttpClient.addResponse(mockJsonResponse2, 200, "OK");
+        LarkBaseService larkBaseService = new LarkBaseService(TEST_APP_ID, TEST_APP_SECRET, mockHttpClient, 2);
+
+        UITypeEnum result = larkBaseService.getLookupType(baseId, "tbl1", "fld1");
+
+        assertEquals(UITypeEnum.UNKNOWN, result);
+    }
+
+    @Test
     public void getTableFields_invalidCacheKey_fallsBackToDirectFetch() throws Exception {
         // Test that the cache loader's IllegalArgumentException path is covered
         String baseId = "base1";

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractorTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractorTest.java
@@ -508,6 +508,43 @@ public class RegistererExtractorTest {
     }
 
     @Test
+    public void testVarCharExtractor_withMultipleTextSegments_concatenatesAllSegments() throws Exception {
+        larkFieldTypeMapping.put("test_field", new NestedUIType(UITypeEnum.TEXT, null));
+        registererExtractor = new RegistererExtractor(larkFieldTypeMapping);
+        when(mockRowWriterBuilder.withExtractor(any(String.class), any())).thenReturn(mockRowWriterBuilder);
+
+        ArgumentCaptor<VarCharExtractor> extractorCaptor = ArgumentCaptor.forClass(VarCharExtractor.class);
+        Field field = new Field("test_field", FieldType.nullable(new ArrowType.Utf8()), null);
+
+        registererExtractor.registerExtractorsForSchema(mockRowWriterBuilder, new Schema(Collections.singletonList(field)));
+        verify(mockRowWriterBuilder).withExtractor(eq("test_field"), extractorCaptor.capture());
+
+        VarCharExtractor extractor = extractorCaptor.getValue();
+
+        // Lark splits a TEXT cell into multiple segments, e.g. when content mixes plain text with an @mention.
+        Map<String, Object> segment1 = new HashMap<>();
+        segment1.put("text", "Please check ");
+        segment1.put("type", "text");
+        Map<String, Object> mentionSegment = new HashMap<>();
+        mentionSegment.put("text", "@Amanda");
+        mentionSegment.put("type", "mention");
+        mentionSegment.put("token", "ou_8240099442cf5da49f04f4bf8f8abcef");
+        mentionSegment.put("mentionType", "User");
+        Map<String, Object> segment3 = new HashMap<>();
+        segment3.put("text", " for review");
+        segment3.put("type", "text");
+
+        Map<String, Object> context = new HashMap<>();
+        context.put("test_field", Arrays.asList(segment1, mentionSegment, segment3));
+        NullableVarCharHolder holder = new NullableVarCharHolder();
+
+        extractor.extract(context, holder);
+
+        assertEquals("Please check @Amanda for review", holder.value);
+        assertEquals(1, holder.isSet);
+    }
+
+    @Test
     public void testVarCharExtractor_withNonStringValue() throws Exception {
         ArgumentCaptor<VarCharExtractor> extractorCaptor = ArgumentCaptor.forClass(VarCharExtractor.class);
         Field field = new Field("test_field", FieldType.nullable(new ArrowType.Utf8()), null);

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslatorTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslatorTest.java
@@ -154,6 +154,29 @@ public class SearchApiFilterTranslatorTest {
     }
 
     @Test
+    public void testToSplitFilterJson_preservesChildrenOrGroup() throws Exception {
+        // An IN-clause is carried as an OR-group under "children" (see toFilterJson). Combining it with a
+        // parallel-split range must not silently drop that group, or the split's fetched rows would ignore
+        // the query's IN-clause entirely.
+        String existingFilter = "{\"conjunction\":\"and\",\"conditions\":[],"
+                + "\"children\":[{\"conjunction\":\"or\",\"conditions\":["
+                + "{\"field_name\":\"status\",\"operator\":\"is\",\"value\":[\"active\"]},"
+                + "{\"field_name\":\"status\",\"operator\":\"is\",\"value\":[\"pending\"]}]}]}";
+
+        String splitFilter = SearchApiFilterTranslator.toSplitFilterJson(existingFilter, 1, 100);
+
+        assertNotNull(splitFilter);
+        JsonNode filter = OBJECT_MAPPER.readTree(splitFilter);
+        assertEquals(2, filter.get("conditions").size()); // just the 2 split-range conditions
+
+        JsonNode children = filter.get("children");
+        assertNotNull(children);
+        assertEquals(1, children.size());
+        assertEquals("or", children.get(0).get("conjunction").asText());
+        assertEquals(2, children.get(0).get("conditions").size());
+    }
+
+    @Test
     public void testToSplitFilterJson_noExistingFilter() throws Exception {
         String splitFilter = SearchApiFilterTranslator.toSplitFilterJson(null, 1, 100);
 
@@ -535,13 +558,102 @@ public class SearchApiFilterTranslatorTest {
 
         assertNotNull(filterJson);
         JsonNode filter = OBJECT_MAPPER.readTree(filterJson);
+
+        // Lark's "is" operator only accepts a single value, so an IN-clause with multiple values must NOT be
+        // emitted as multiple top-level "is" conditions ANDed together (that would require the field to equal
+        // both values at once and always match zero rows). It must be an OR-group nested under "children".
         JsonNode conditions = filter.get("conditions");
-        assertEquals(2, conditions.size());
-        assertEquals("Text Field", conditions.get(0).get("field_name").asText());
+        assertEquals(0, conditions.size());
+
+        JsonNode children = filter.get("children");
+        assertEquals(1, children.size());
+        JsonNode orGroup = children.get(0);
+        assertEquals("or", orGroup.get("conjunction").asText());
+        JsonNode orConditions = orGroup.get("conditions");
+        assertEquals(2, orConditions.size());
+        assertEquals("Text Field", orConditions.get(0).get("field_name").asText());
+        assertEquals("is", orConditions.get(0).get("operator").asText());
+        assertEquals("value1", orConditions.get(0).get("value").get(0).asText());
+        assertEquals("is", orConditions.get(1).get("operator").asText());
+        assertEquals("value2", orConditions.get(1).get("value").get(0).asText());
+    }
+
+    @Test
+    public void testToFilterJson_withEquatableValueSet_whitelistSingleValue_staysFlatCondition() throws Exception {
+        // A single-value IN-clause (effectively "=") should stay a plain top-level condition, not a "children" group.
+        EquatableValueSet valueSet = mock(EquatableValueSet.class);
+        when(valueSet.isWhiteList()).thenReturn(true);
+        when(valueSet.isNullAllowed()).thenReturn(false);
+        when(valueSet.getType()).thenReturn(new ArrowType.Utf8());
+
+        Block block = mock(Block.class);
+        when(block.getRowCount()).thenReturn(1);
+        when(valueSet.getValueBlock()).thenReturn(block);
+        when(valueSet.getValue(0)).thenReturn("value1");
+
+        Map<String, ValueSet> constraints = new HashMap<>();
+        constraints.put("field_text", valueSet);
+
+        List<AthenaFieldLarkBaseMapping> mappings = Collections.singletonList(
+            new AthenaFieldLarkBaseMapping("field_text", "Text Field",
+                new NestedUIType(UITypeEnum.TEXT, null)));
+
+        String filterJson = SearchApiFilterTranslator.toFilterJson(constraints, mappings);
+
+        JsonNode filter = OBJECT_MAPPER.readTree(filterJson);
+        JsonNode conditions = filter.get("conditions");
+        assertEquals(1, conditions.size());
         assertEquals("is", conditions.get(0).get("operator").asText());
-        assertEquals("value1", conditions.get(0).get("value").get(0).asText());
-        assertEquals("is", conditions.get(1).get("operator").asText());
-        assertEquals("value2", conditions.get(1).get("value").get(0).asText());
+        assertNull(filter.get("children"));
+    }
+
+    @Test
+    public void testToFilterJson_withEquatableValueSet_multiValueInClauseCombinedWithOtherColumn() throws Exception {
+        // WHERE status IN ('active', 'pending') AND priority = 'high'
+        EquatableValueSet inClauseValueSet = mock(EquatableValueSet.class);
+        when(inClauseValueSet.isWhiteList()).thenReturn(true);
+        when(inClauseValueSet.isNullAllowed()).thenReturn(false);
+        when(inClauseValueSet.getType()).thenReturn(new ArrowType.Utf8());
+        Block inClauseBlock = mock(Block.class);
+        when(inClauseBlock.getRowCount()).thenReturn(2);
+        when(inClauseValueSet.getValueBlock()).thenReturn(inClauseBlock);
+        when(inClauseValueSet.getValue(0)).thenReturn("active");
+        when(inClauseValueSet.getValue(1)).thenReturn("pending");
+
+        EquatableValueSet equalityValueSet = mock(EquatableValueSet.class);
+        when(equalityValueSet.isWhiteList()).thenReturn(true);
+        when(equalityValueSet.isNullAllowed()).thenReturn(false);
+        when(equalityValueSet.getType()).thenReturn(new ArrowType.Utf8());
+        Block equalityBlock = mock(Block.class);
+        when(equalityBlock.getRowCount()).thenReturn(1);
+        when(equalityValueSet.getValueBlock()).thenReturn(equalityBlock);
+        when(equalityValueSet.getValue(0)).thenReturn("high");
+
+        Map<String, ValueSet> constraints = new LinkedHashMap<>();
+        constraints.put("status", inClauseValueSet);
+        constraints.put("priority", equalityValueSet);
+
+        List<AthenaFieldLarkBaseMapping> mappings = Arrays.asList(
+            new AthenaFieldLarkBaseMapping("status", "Status", new NestedUIType(UITypeEnum.TEXT, null)),
+            new AthenaFieldLarkBaseMapping("priority", "Priority", new NestedUIType(UITypeEnum.TEXT, null)));
+
+        String filterJson = SearchApiFilterTranslator.toFilterJson(constraints, mappings);
+
+        JsonNode filter = OBJECT_MAPPER.readTree(filterJson);
+        assertEquals("and", filter.get("conjunction").asText());
+
+        // The single-value equality condition stays a flat, top-level AND condition.
+        JsonNode conditions = filter.get("conditions");
+        assertEquals(1, conditions.size());
+        assertEquals("Priority", conditions.get(0).get("field_name").asText());
+
+        // The multi-value IN-clause becomes its own OR-group.
+        JsonNode children = filter.get("children");
+        assertEquals(1, children.size());
+        JsonNode orGroup = children.get(0);
+        assertEquals("or", orGroup.get("conjunction").asText());
+        assertEquals(2, orGroup.get("conditions").size());
+        assertEquals("Status", orGroup.get("conditions").get(0).get("field_name").asText());
     }
 
     @Test
@@ -572,6 +684,38 @@ public class SearchApiFilterTranslatorTest {
         assertEquals(1, conditions.size());
         assertEquals("isNot", conditions.get(0).get("operator").asText());
         assertEquals("excluded", conditions.get(0).get("value").get(0).asText());
+    }
+
+    @Test
+    public void testToFilterJson_withEquatableValueSet_multiValueBlacklist_staysFlatAndCondition() throws Exception {
+        // WHERE field NOT IN ('a', 'b') is correctly "field != a AND field != b" - unlike the whitelist (IN) case,
+        // ANDing multiple "isNot" conditions together is already correct, so this must stay flat, not grouped.
+        EquatableValueSet valueSet = mock(EquatableValueSet.class);
+        when(valueSet.isWhiteList()).thenReturn(false);
+        when(valueSet.isNullAllowed()).thenReturn(false);
+        when(valueSet.getType()).thenReturn(new ArrowType.Utf8());
+
+        Block block = mock(Block.class);
+        when(block.getRowCount()).thenReturn(2);
+        when(valueSet.getValueBlock()).thenReturn(block);
+        when(valueSet.getValue(0)).thenReturn("a");
+        when(valueSet.getValue(1)).thenReturn("b");
+
+        Map<String, ValueSet> constraints = new HashMap<>();
+        constraints.put("field_text", valueSet);
+
+        List<AthenaFieldLarkBaseMapping> mappings = Collections.singletonList(
+            new AthenaFieldLarkBaseMapping("field_text", "Text Field",
+                new NestedUIType(UITypeEnum.TEXT, null)));
+
+        String filterJson = SearchApiFilterTranslator.toFilterJson(constraints, mappings);
+
+        JsonNode filter = OBJECT_MAPPER.readTree(filterJson);
+        JsonNode conditions = filter.get("conditions");
+        assertEquals(2, conditions.size());
+        assertEquals("isNot", conditions.get(0).get("operator").asText());
+        assertEquals("isNot", conditions.get(1).get("operator").asText());
+        assertNull(filter.get("children"));
     }
 
     @Test

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtilTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtilTest.java
@@ -164,6 +164,44 @@ class CommonUtilTest {
     }
 
     @Test
+    void testExtractFieldTypeFromComment_ChainedLookupType_TwoLevels() {
+        // A LOOKUP field whose target is itself a LOOKUP field is written by the Glue Crawler
+        // (BaseLarkBaseCrawlerHandler.getLarkBaseOriginalColumnType) as a nested string. The terminal type
+        // (Number) must be extracted, not the intermediate "Lookup" level.
+        String comment = "LarkBaseFieldType=Lookup<Lookup<Number>>/LarkBaseFieldName=ChainedLookup";
+
+        NestedUIType result = CommonUtil.extractFieldTypeFromComment(comment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.uiType()).isEqualTo(UITypeEnum.LOOKUP);
+        assertThat(result.childType()).isEqualTo(UITypeEnum.NUMBER);
+    }
+
+    @Test
+    void testExtractFieldTypeFromComment_ChainedLookupType_ThreeLevels() {
+        String comment = "LarkBaseFieldType=Lookup<Lookup<Lookup<DateTime>>>/LarkBaseFieldName=DeepChainedLookup";
+
+        NestedUIType result = CommonUtil.extractFieldTypeFromComment(comment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.uiType()).isEqualTo(UITypeEnum.LOOKUP);
+        assertThat(result.childType()).isEqualTo(UITypeEnum.DATE_TIME);
+    }
+
+    @Test
+    void testExtractFieldTypeFromComment_LookupType_UnresolvedTargetFallsBackToUnknown() {
+        // The crawler writes "Lookup<NULL>" when the lookup target couldn't be resolved
+        // (see BaseLarkBaseCrawlerHandler.getLarkBaseOriginalColumnType's NULL fallback branches).
+        String comment = "LarkBaseFieldType=Lookup<NULL>/LarkBaseFieldName=BrokenLookup";
+
+        NestedUIType result = CommonUtil.extractFieldTypeFromComment(comment);
+
+        assertThat(result).isNotNull();
+        assertThat(result.uiType()).isEqualTo(UITypeEnum.LOOKUP);
+        assertThat(result.childType()).isEqualTo(UITypeEnum.UNKNOWN);
+    }
+
+    @Test
     void testExtractFieldTypeFromComment_Null() {
         // Arrange & Act
         NestedUIType result = CommonUtil.extractFieldTypeFromComment(null);

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/util/LarkBaseTypeUtilsTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/util/LarkBaseTypeUtilsTest.java
@@ -190,6 +190,42 @@ class LarkBaseTypeUtilsTest {
         assertThat(result).isEqualTo(Types.MinorType.STRUCT);
     }
 
+    // Test larkFieldToArrowMinorType for LOOKUP type
+    // This is the test that would have caught the dead-code bug where LarkBaseTableResolver and
+    // ExperimentalMetadataProvider could never actually populate childType() for a genuine LOOKUP field: with
+    // no case LOOKUP here, every LOOKUP field silently fell through to the default VARCHAR branch instead of LIST.
+    @Test
+    void testLarkFieldToArrowMinorType_LookupWithTextTarget() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.TEXT));
+
+        Types.MinorType result = LarkBaseTypeUtils.larkFieldToArrowMinorType(field);
+
+        assertThat(result).isEqualTo(Types.MinorType.LIST);
+    }
+
+    @Test
+    void testLarkFieldToArrowMinorType_LookupWithNumberTarget() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.NUMBER));
+
+        Types.MinorType result = LarkBaseTypeUtils.larkFieldToArrowMinorType(field);
+
+        assertThat(result).isEqualTo(Types.MinorType.LIST);
+    }
+
+    @Test
+    void testLarkFieldToArrowMinorType_LookupWithUnresolvedTarget() {
+        // childType is UNKNOWN when the target couldn't be resolved (broken reference, API error, cycle).
+        // The field must still be a LIST at the top level - only the child element type falls back to string.
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.UNKNOWN));
+
+        Types.MinorType result = LarkBaseTypeUtils.larkFieldToArrowMinorType(field);
+
+        assertThat(result).isEqualTo(Types.MinorType.LIST);
+    }
+
     // Test larkFieldToArrowMinorType for FORMULA type
     @Test
     void testLarkFieldToArrowMinorType_FormulaWithNumber() {
@@ -319,6 +355,99 @@ class LarkBaseTypeUtilsTest {
 
         assertThat(result.getName()).isEqualTo("item");
         assertThat(result.getType()).isEqualTo(ArrowType.Utf8.INSTANCE);
+    }
+
+    @Test
+    void testGetLarkListChildField_LookupWithNumber() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.NUMBER));
+
+        Field result = LarkBaseTypeUtils.getLarkListChildField(field);
+
+        assertThat(result.getName()).isEqualTo("item");
+        assertThat(result.getType()).isEqualTo(new ArrowType.Decimal(38, 18, 128));
+    }
+
+    @Test
+    void testGetLarkListChildField_LookupWithCurrency() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.CURRENCY));
+
+        Field result = LarkBaseTypeUtils.getLarkListChildField(field);
+
+        assertThat(result.getType()).isEqualTo(new ArrowType.Decimal(38, 18, 128));
+    }
+
+    @Test
+    void testGetLarkListChildField_LookupWithCheckbox() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.CHECKBOX));
+
+        Field result = LarkBaseTypeUtils.getLarkListChildField(field);
+
+        assertThat(result.getName()).isEqualTo("item");
+        assertThat(result.getType()).isEqualTo(ArrowType.Bool.INSTANCE);
+    }
+
+    @Test
+    void testGetLarkListChildField_LookupWithDateTime() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.DATE_TIME));
+
+        Field result = LarkBaseTypeUtils.getLarkListChildField(field);
+
+        assertThat(result.getName()).isEqualTo("item");
+        assertThat(result.getType()).isEqualTo(new ArrowType.Timestamp(org.apache.arrow.vector.types.TimeUnit.MILLISECOND, "UTC"));
+    }
+
+    @Test
+    void testGetLarkListChildField_LookupWithRating() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.RATING));
+
+        Field result = LarkBaseTypeUtils.getLarkListChildField(field);
+
+        assertThat(result.getName()).isEqualTo("item");
+        assertThat(result.getType()).isEqualTo(Types.MinorType.TINYINT.getType());
+    }
+
+    @Test
+    void testGetLarkListChildField_LookupWithUnresolvedTarget_fallsBackToString() {
+        // childType UNKNOWN (target couldn't be resolved) must fall back to a plain string element,
+        // matching the Glue Crawler path's "array<string>" fallback - not throw or produce a null type.
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.UNKNOWN));
+
+        Field result = LarkBaseTypeUtils.getLarkListChildField(field);
+
+        assertThat(result.getName()).isEqualTo("item");
+        assertThat(result.getType()).isEqualTo(ArrowType.Utf8.INSTANCE);
+    }
+
+    @Test
+    void testGetLarkListChildField_LookupWithNullTarget_fallsBackToString() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup", new NestedUIType(UITypeEnum.LOOKUP, null));
+
+        Field result = LarkBaseTypeUtils.getLarkListChildField(field);
+
+        assertThat(result.getName()).isEqualTo("item");
+        assertThat(result.getType()).isEqualTo(ArrowType.Utf8.INSTANCE);
+    }
+
+    // End-to-end: larkFieldToArrowField for a LOOKUP field must produce a LIST Field whose single child carries
+    // the resolved target type - this is the full schema shape Athena actually sees for a LOOKUP column.
+    @Test
+    void testLarkFieldToArrowField_LookupWithNumber_producesListOfDecimal() {
+        AthenaFieldLarkBaseMapping field = new AthenaFieldLarkBaseMapping(
+                "lookup_field", "Lookup Field", new NestedUIType(UITypeEnum.LOOKUP, UITypeEnum.NUMBER));
+
+        Field result = LarkBaseTypeUtils.larkFieldToArrowField(field);
+
+        assertThat(result.getName()).isEqualTo("Lookup Field");
+        assertThat(result.getType()).isEqualTo(ArrowType.List.INSTANCE);
+        assertThat(result.getChildren()).hasSize(1);
+        assertThat(result.getChildren().get(0).getType()).isEqualTo(new ArrowType.Decimal(38, 18, 128));
     }
 
     // Test getLarkStructChildFields for URL

--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/model/response/ListFieldResponse.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/model/response/ListFieldResponse.java
@@ -28,6 +28,7 @@ import software.amazon.awssdk.utils.Pair;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.amazonaws.glue.lark.base.crawler.model.enums.UITypeEnum.BUTTON;
 import static com.amazonaws.glue.lark.base.crawler.model.enums.UITypeEnum.STAGE;
@@ -83,7 +84,16 @@ public final class ListFieldResponse extends BaseResponse<ListFieldResponse.List
         {
             this.fieldId = builder.fieldId;
             this.fieldName = builder.fieldName;
-            this.property = builder.property != null ? Map.copyOf(builder.property) : Collections.emptyMap();
+            // Ensure immutable map, filter out null values (Lark returns null for unset properties)
+            if (builder.property != null) {
+                Map<String, Object> nonNullProperty = builder.property.entrySet().stream()
+                        .filter(e -> e.getValue() != null)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                this.property = Map.copyOf(nonNullProperty);
+            }
+            else {
+                this.property = Collections.emptyMap();
+            }
             this.description = builder.description;
             this.isPrimary = builder.isPrimary;
             this.required = builder.required;

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/model/response/ListFieldResponseTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/model/response/ListFieldResponseTest.java
@@ -22,6 +22,7 @@ package com.amazonaws.glue.lark.base.crawler.model.response;
 import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -53,6 +54,26 @@ public class ListFieldResponseTest {
         assertEquals(items, response.getItems());
         assertEquals("nextPage", response.getPageToken());
         assertTrue(response.hasMore());
+    }
+
+    @Test
+    public void fieldItem_property_whenValuesAreNull_shouldFilterThemOut() {
+        Map<String, Object> propertyWithNull = new HashMap<>();
+        propertyWithNull.put("formatter", "0.00");
+        propertyWithNull.put("date_formatter", null);
+        propertyWithNull.put("auto_fill", true);
+
+        ListFieldResponse.FieldItem item = ListFieldResponse.FieldItem.builder()
+                .fieldId("f1")
+                .fieldName("Field")
+                .uiType("Number")
+                .property(propertyWithNull)
+                .build();
+
+        assertEquals(2, item.getProperty().size());
+        assertTrue(item.getProperty().containsKey("formatter"));
+        assertTrue(item.getProperty().containsKey("auto_fill"));
+        assertFalse(item.getProperty().containsKey("date_formatter"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

A handful of bugs found while going through the connector's filter pushdown and LOOKUP field handling:

- **TEXT fields** with @mentions or links mixed into the content were getting truncated to just the first segment.
- **Field property parsing** could crash on null values Lark now returns for unset properties.
- **IN-clause filters** (`WHERE x IN (a, b)`) were being pushed down as `x = a AND x = b`, which can never match anything with more than one value - always returned zero rows.
- **LOOKUP field resolution** was dead code in the two non-crawler discovery paths, so lookup target types were never actually resolved, and separately, `LarkBaseTypeUtils` had no mapping for LOOKUP at all, so those columns fell back to plain VARCHAR instead of the correct array type. Chained LOOKUP parsing from Glue comments only captured the first nesting level instead of the terminal type.
- **Circular/deep LOOKUP chains** could recurse forever and crash schema discovery - added cycle detection and a configurable depth cap.
- **Parallel split planning** ignored filter selectivity, so a highly selective query (e.g. `WHERE id = 'x'`) on a large table would still spawn hundreds of splits that mostly returned nothing.

Also added a Known Limitations doc section covering NUMBER field precision loss, which is a Lark Base platform behavior (confirmed via direct API testing) rather than something fixable in the connector.

## Test plan

- [x] Full module test suite passes (`mvn test`)
- [x] Checkstyle passes
- [x] IN-clause fix verified against Lark's live Search Records API before implementation
- [x] New/updated unit tests for each fix