### PR TITLE
Add per-schema table whitelist/blacklist

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -963,9 +963,37 @@ splits that would mostly return zero rows (e.g. `WHERE id = 'x'` on a 100,000-ro
 | `ACTIVATE_EXPERIMENTAL_FEATURES` | No | false | Enable experimental metadata provider |
 | `ACTIVATE_PARALLEL_SPLIT` | No | false | Enable parallel split execution |
 | `ENABLE_DEBUG_LOGGING` | No | false | Enable detailed debug logs |
+| `LARK_LOOKUP_MAX_DEPTH` | No | 20 | Max hops followed when resolving a chained LOOKUP field's type |
+| `WHITELIST_TABLES` | No | - | Per-schema table allowlist, format `schemaName:tableName,...` (see [Table Access Control](#table-access-control)) |
+| `BLACKLIST_TABLES` | No | - | Per-schema table denylist, same format; always wins over `WHITELIST_TABLES` |
 | `LARK_BASE_DATA_SOURCE_ID` | Conditional | - | Base ID for table discovery (if LARK_BASE_SOURCE) |
 | `LARK_TABLE_DATA_SOURCE_ID` | Conditional | - | Table ID for table discovery (if LARK_BASE_SOURCE) |
 | `LARK_FOLDER_TOKEN_DATA_SOURCE` | Conditional | - | Folder token for discovery (if LARK_DRIVE_SOURCE) |
+
+### Table Access Control
+
+The connector (Lambda) and the Glue Crawler each have their own independent whitelist/blacklist mechanism,
+matching where each component naturally has the relevant information available:
+
+**Connector (`athena-lark-base`)** - controlled directly via `WHITELIST_TABLES_ENV_VAR` /
+`BLACKLIST_TABLES_ENV_VAR` (format: `schemaName:tableName,schemaName:tableName2,...`, matched
+case-insensitively against the Athena-facing schema/table names). This applies uniformly on top of
+whatever metadata discovery path is active (Glue Catalog, Lark Base Source, Lark Drive Source, or
+Experimental) - it is a final gate, not tied to any one discovery mechanism. A schema with no whitelist
+entries is unrestricted by the whitelist; the blacklist always wins if a table appears in both. Enforcement
+is a full block: a disallowed table is filtered out of `doListTables` (hidden from `SHOW TABLES`) and
+`doGetTable` throws `ENTITY_NOT_FOUND_EXCEPTION` for it (so a direct `SELECT`/`DESCRIBE` fails as if the
+table doesn't exist), since Athena always resolves a table's schema via `doGetTable` before executing a
+query against it.
+
+**Glue Crawler (`glue-lark-base-crawler`)** - controlled from Lark Base itself: the crawler's existing
+control table (configured via `LARK_BASE_DATA_SOURCE_ID`/`LARK_TABLE_DATA_SOURCE_ID`, one row per database
+with `id`/`name` columns) supports two additional optional columns, `whitelist_tables` and
+`blacklist_tables`, each a comma-separated list of Lark **table IDs** (not names, since table IDs are
+stable across renames) to restrict that database's crawl. The crawler filters the tables it discovers in
+Lark against these lists before deciding what to create/update in Glue, so a table that becomes blacklisted
+(or falls outside a newly-added whitelist) after having already been crawled is deleted from Glue on the
+next crawl run, the same as if it had been deleted in Lark.
 
 ### AWS Secrets Manager
 

--- a/METADATA_DISCOVERY_FLOWS.md
+++ b/METADATA_DISCOVERY_FLOWS.md
@@ -161,14 +161,18 @@ Table: databases
 Columns:
   - id (TEXT): Lark Base ID (e.g., "bascnxxxxxx")
   - name (TEXT): Glue database name (lowercase, underscores only)
+  - whitelist_tables (TEXT, optional): comma-separated Lark table IDs to exclusively crawl for this
+    database. Leave blank to crawl all tables (subject to blacklist_tables).
+  - blacklist_tables (TEXT, optional): comma-separated Lark table IDs to always exclude from crawling
+    for this database. Takes precedence over whitelist_tables.
 ```
 
 Example data:
 ```
-| id                   | name              |
-|---------------------|-------------------|
-| bascnABC123456789   | sales_data        |
-| bascnDEF987654321   | customer_records  |
+| id                   | name              | whitelist_tables | blacklist_tables |
+|---------------------|-------------------|-------------------|-------------------|
+| bascnABC123456789   | sales_data        |                   | tblARCHIVED123    |
+| bascnDEF987654321   | customer_records  | tblACTIVE111,tblACTIVE222 |           |
 ```
 
 **Step 3: Run Crawler**

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ JAVA_HOME="/path/to/jdk-17" mvn checkstyle:check
 | `ACTIVATE_PARALLEL_SPLIT` | No | Enable parallel split execution |
 | `ENABLE_DEBUG_LOGGING` | No | Enable detailed debug logs |
 | `LARK_LOOKUP_MAX_DEPTH` | No | Max hops followed when resolving a chained LOOKUP field's type (default: 20). Also caps runaway resolution if a Lark Base has a misconfigured circular LOOKUP reference |
+| `WHITELIST_TABLES` | No | Restricts, per schema, which tables the connector exposes. Format: `schemaName:tableName,schemaName:tableName2,...`. A schema with no entries here is unrestricted by this setting |
+| `BLACKLIST_TABLES` | No | Excludes, per schema, specific tables from the connector regardless of `WHITELIST_TABLES`. Same format. A table listed here is never visible or queryable (blocked in both `SHOW TABLES` and direct `SELECT`) |
 
 See [ARCHITECTURE.md#Configuration](./ARCHITECTURE.md#configuration) for complete reference.
 

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseConstants.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseConstants.java
@@ -90,6 +90,22 @@ public final class BaseConstants
     public static final String LARK_DRIVE_SOURCES_ENV_VAR = "default_lark_drive_sources";
 
     /**
+     * The environment variable which restricts, per schema, which tables the connector will expose.
+     * When a schema has at least one entry here, only those tables are visible/queryable for that schema;
+     * schemas with no entry are unrestricted by this setting. Evaluated independently of
+     * {@link #BLACKLIST_TABLES_ENV_VAR} (blacklist always wins if a table appears in both).
+     * format: [schemaName:tableName,schemaName:tableName2,...]
+     */
+    public static final String WHITELIST_TABLES_ENV_VAR = "default_whitelist_tables";
+
+    /**
+     * The environment variable which excludes, per schema, specific tables from the connector regardless of
+     * {@link #WHITELIST_TABLES_ENV_VAR}. A table listed here is never visible or queryable.
+     * format: [schemaName:tableName,schemaName:tableName2,...]
+     */
+    public static final String BLACKLIST_TABLES_ENV_VAR = "default_blacklist_tables";
+
+    /**
      * The lark base flag which is used to identify the custom flag on glue catalog.
      */
     public static final String LARK_BASE_FLAG = "lark-base-flag";

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandler.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandler.java
@@ -28,6 +28,7 @@ import com.amazonaws.athena.connector.lambda.data.BlockWriter;
 import com.amazonaws.athena.connector.lambda.data.SchemaBuilder;
 import com.amazonaws.athena.connector.lambda.domain.Split;
 import com.amazonaws.athena.connector.lambda.domain.TableName;
+import com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException;
 import com.amazonaws.athena.connector.lambda.handlers.GlueMetadataHandler;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesRequest;
 import com.amazonaws.athena.connector.lambda.metadata.GetDataSourceCapabilitiesResponse;
@@ -73,6 +74,8 @@ import software.amazon.awssdk.services.athena.AthenaClient;
 import software.amazon.awssdk.services.glue.GlueClient;
 import software.amazon.awssdk.services.glue.model.Database;
 import software.amazon.awssdk.services.glue.model.EntityNotFoundException;
+import software.amazon.awssdk.services.glue.model.ErrorDetails;
+import software.amazon.awssdk.services.glue.model.FederationSourceErrorCode;
 import software.amazon.awssdk.services.glue.model.Table;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.utils.Pair;
@@ -358,12 +361,29 @@ public class BaseMetadataHandler
             }
         }
 
+        combinedTables.removeIf(tableName -> !isTableAccessAllowed(tableName.getSchemaName(), tableName.getTableName()));
+
         if (envVarService.isEnableDebugLogging()) {
             logger.info("doListTables: exit - returning {} tables for schema {}",
                     combinedTables.size(), requestedSchema);
         }
 
         return new ListTablesResponse(request.getCatalogName(), new ArrayList<>(combinedTables), null);
+    }
+
+    /**
+     * Checks whether a table should be visible/queryable given the connector's configured
+     * WHITELIST_TABLES_ENV_VAR / BLACKLIST_TABLES_ENV_VAR settings.
+     *
+     * @param schemaName The schema (database) name.
+     * @param tableName The table name.
+     * @return true if the table should be visible/queryable.
+     */
+    private boolean isTableAccessAllowed(String schemaName, String tableName)
+    {
+        Map<String, Set<String>> whitelistTables = CommonUtil.parseSchemaTableGrouping(envVarService.getWhitelistTables());
+        Map<String, Set<String>> blacklistTables = CommonUtil.parseSchemaTableGrouping(envVarService.getBlacklistTables());
+        return CommonUtil.isTableAccessAllowed(schemaName, tableName, whitelistTables, blacklistTables);
     }
 
     /**
@@ -385,6 +405,13 @@ public class BaseMetadataHandler
     {
         if (envVarService.isEnableDebugLogging()) {
             logger.info("doGetTable: Using Strategy Pattern for table {}", request.getTableName());
+        }
+
+        TableName tableName = request.getTableName();
+        if (!isTableAccessAllowed(tableName.getSchemaName(), tableName.getTableName())) {
+            logger.warn("doGetTable: Table {} is blocked by WHITELIST_TABLES_ENV_VAR/BLACKLIST_TABLES_ENV_VAR configuration.", tableName);
+            throw new AthenaConnectorException("Table not found: " + tableName,
+                    ErrorDetails.builder().errorCode(FederationSourceErrorCode.ENTITY_NOT_FOUND_EXCEPTION.toString()).build());
         }
 
         if (envVarService.isActivateLarkBaseSource() || envVarService.isActivateLarkDriveSource()) {

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/service/EnvVarService.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/service/EnvVarService.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
+import static com.amazonaws.athena.connectors.lark.base.BaseConstants.BLACKLIST_TABLES_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DEFAULT_LARK_LOOKUP_MAX_DEPTH;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DOES_ACTIVATE_EXPERIMENTAL_FEATURE_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.DOES_ACTIVATE_LARK_BASE_SOURCE_ENV_VAR;
@@ -39,6 +40,7 @@ import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_APP_K
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_BASE_SOURCES_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_DRIVE_SOURCES_ENV_VAR;
 import static com.amazonaws.athena.connectors.lark.base.BaseConstants.LARK_LOOKUP_MAX_DEPTH_ENV_VAR;
+import static com.amazonaws.athena.connectors.lark.base.BaseConstants.WHITELIST_TABLES_ENV_VAR;
 import static java.util.Objects.requireNonNull;
 
 public class EnvVarService
@@ -56,6 +58,8 @@ public class EnvVarService
     private final String larkBaseSources;
     private final String larkDriveSources;
     private final int lookupMaxDepth;
+    private final String whitelistTables;
+    private final String blacklistTables;
 
     public EnvVarService(Map<String, String> configOptions, ThrottlingInvoker invoker)
     {
@@ -95,6 +99,8 @@ public class EnvVarService
         this.larkBaseSources = configOptions.getOrDefault(LARK_BASE_SOURCES_ENV_VAR, "");
         this.larkDriveSources = configOptions.getOrDefault(LARK_DRIVE_SOURCES_ENV_VAR, "");
         this.lookupMaxDepth = parseLookupMaxDepth(configOptions.get(LARK_LOOKUP_MAX_DEPTH_ENV_VAR));
+        this.whitelistTables = configOptions.getOrDefault(WHITELIST_TABLES_ENV_VAR, "");
+        this.blacklistTables = configOptions.getOrDefault(BLACKLIST_TABLES_ENV_VAR, "");
     }
 
     private static int parseLookupMaxDepth(String rawValue)
@@ -159,5 +165,15 @@ public class EnvVarService
     public int getLookupMaxDepth()
     {
         return lookupMaxDepth;
+    }
+
+    public String getWhitelistTables()
+    {
+        return whitelistTables;
+    }
+
+    public String getBlacklistTables()
+    {
+        return blacklistTables;
     }
 }

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtil.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtil.java
@@ -231,6 +231,76 @@ public final class CommonUtil
     }
 
     /**
+     * Parses a "schemaName:tableName,schemaName:tableName2,..." environment variable string (used by
+     * {@code WHITELIST_TABLES_ENV_VAR} / {@code BLACKLIST_TABLES_ENV_VAR}) into a schema-to-table-names map.
+     * Both schema and table names are lowercased so lookups can be done case-insensitively, matching how
+     * Athena/Glue names are already normalized elsewhere in this connector.
+     *
+     * @param fromEnvVar The environment variable string.
+     * @return Map of lowercased schema name to a set of lowercased table names, or an empty map if unset.
+     */
+    public static Map<String, Set<String>> parseSchemaTableGrouping(String fromEnvVar)
+    {
+        if (fromEnvVar == null || fromEnvVar.trim().isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Set<String>> schemaToTableNames = new HashMap<>();
+
+        String[] entries = fromEnvVar.split(",");
+        for (String entry : entries) {
+            String trimmedEntry = entry.trim();
+            if (trimmedEntry.isEmpty()) {
+                continue;
+            }
+            String[] parts = trimmedEntry.split(":", 2);
+            if (parts.length == 2) {
+                String schemaName = parts[0].trim().toLowerCase();
+                String tableName = parts[1].trim().toLowerCase();
+
+                if (schemaName.isEmpty() || tableName.isEmpty()) {
+                    continue;
+                }
+
+                schemaToTableNames.computeIfAbsent(schemaName, k -> new HashSet<>()).add(tableName);
+            }
+        }
+
+        return schemaToTableNames;
+    }
+
+    /**
+     * Decides whether a table should be visible/queryable given the connector's configured whitelist and
+     * blacklist. The blacklist always wins: a table listed there is blocked even if it also matches the
+     * whitelist. The whitelist only restricts schemas that have at least one entry in it - a schema with no
+     * whitelist entries is unrestricted by the whitelist (only the blacklist, if any, applies to it).
+     *
+     * @param schemaName The schema (database) name, matched case-insensitively.
+     * @param tableName The table name, matched case-insensitively.
+     * @param whitelistTables Schema-to-table-names map from {@link #parseSchemaTableGrouping}, or empty if unset.
+     * @param blacklistTables Schema-to-table-names map from {@link #parseSchemaTableGrouping}, or empty if unset.
+     * @return true if the table should be visible/queryable.
+     */
+    public static boolean isTableAccessAllowed(String schemaName, String tableName,
+            Map<String, Set<String>> whitelistTables, Map<String, Set<String>> blacklistTables)
+    {
+        String normalizedSchema = schemaName == null ? "" : schemaName.toLowerCase();
+        String normalizedTable = tableName == null ? "" : tableName.toLowerCase();
+
+        Set<String> blacklistedTables = blacklistTables.get(normalizedSchema);
+        if (blacklistedTables != null && blacklistedTables.contains(normalizedTable)) {
+            return false;
+        }
+
+        Set<String> whitelistedTables = whitelistTables.get(normalizedSchema);
+        if (whitelistedTables != null && !whitelistedTables.isEmpty()) {
+            return whitelistedTables.contains(normalizedTable);
+        }
+
+        return true;
+    }
+
+    /**
      * Enhances the original table schema by adding connector-specific reserved fields.
      * These fields provide additional context about the record's origin within Lark Base.
      * (Moved from BaseMetadataHandler.generateNewTableResponse)

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandlerTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/BaseMetadataHandlerTest.java
@@ -121,6 +121,61 @@ public class BaseMetadataHandlerTest {
     }
 
     @Test
+    public void testDoGetTable_BlacklistedTable_ThrowsAthenaConnectorException() {
+        when(mockEnvVarService.getWhitelistTables()).thenReturn("");
+        when(mockEnvVarService.getBlacklistTables()).thenReturn("schemaa:table1");
+
+        com.amazonaws.athena.connector.lambda.security.FederatedIdentity identity =
+                new com.amazonaws.athena.connector.lambda.security.FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap());
+        GetTableRequest request = new GetTableRequest(identity, "queryId", "catalog",
+                new com.amazonaws.athena.connector.lambda.domain.TableName("schemaA", "table1"), Collections.emptyMap());
+
+        assertThrows(com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException.class,
+                () -> handler.doGetTable(allocator, request));
+    }
+
+    @Test
+    public void testDoGetTable_TableNotInWhitelistedSchema_ThrowsAthenaConnectorException() {
+        when(mockEnvVarService.getWhitelistTables()).thenReturn("schemaa:table1,schemaa:table2");
+        when(mockEnvVarService.getBlacklistTables()).thenReturn("");
+
+        com.amazonaws.athena.connector.lambda.security.FederatedIdentity identity =
+                new com.amazonaws.athena.connector.lambda.security.FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap());
+        GetTableRequest request = new GetTableRequest(identity, "queryId", "catalog",
+                new com.amazonaws.athena.connector.lambda.domain.TableName("schemaA", "table3"), Collections.emptyMap());
+
+        assertThrows(com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException.class,
+                () -> handler.doGetTable(allocator, request));
+    }
+
+    @Test
+    public void testDoGetTable_TableInWhitelistedSchema_DoesNotThrowFromAccessControlGuard() {
+        when(mockEnvVarService.getWhitelistTables()).thenReturn("schemaa:table1");
+        when(mockEnvVarService.getBlacklistTables()).thenReturn("");
+        when(mockEnvVarService.isActivateLarkBaseSource()).thenReturn(false);
+        when(mockEnvVarService.isActivateLarkDriveSource()).thenReturn(false);
+        when(mockEnvVarService.isActivateExperimentalFeatures()).thenReturn(false);
+
+        com.amazonaws.athena.connector.lambda.security.FederatedIdentity identity =
+                new com.amazonaws.athena.connector.lambda.security.FederatedIdentity("arn", "account", Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap());
+        GetTableRequest request = new GetTableRequest(identity, "queryId", "catalog",
+                new com.amazonaws.athena.connector.lambda.domain.TableName("schemaA", "table1"), Collections.emptyMap());
+
+        // The access-control guard must not be what blocks this table (it's allowed); whatever the handler
+        // does next (Glue fallback failing since nothing is mocked further) is out of scope for this test.
+        try {
+            handler.doGetTable(allocator, request);
+        }
+        catch (com.amazonaws.athena.connector.lambda.exceptions.AthenaConnectorException e) {
+            assertFalse("Access-control guard should not be the cause of failure for an allowed table",
+                    e.getMessage() != null && e.getMessage().contains("Table not found"));
+        }
+        catch (Exception e) {
+            // Any other failure downstream (e.g. Glue fallback) is unrelated to the access-control guard.
+        }
+    }
+
+    @Test
     public void testDoGetDataSourceCapabilities() {
         GetDataSourceCapabilitiesRequest request = mock(GetDataSourceCapabilitiesRequest.class);
         when(request.getCatalogName()).thenReturn("test-catalog");

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtilTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/util/CommonUtilTest.java
@@ -373,6 +373,111 @@ class CommonUtilTest {
     }
 
     @Test
+    void testParseSchemaTableGrouping_Valid() {
+        String envVar = "schemaA:table1,schemaA:table2,schemaB:table3";
+
+        Map<String, Set<String>> result = CommonUtil.parseSchemaTableGrouping(envVar);
+
+        assertThat(result).hasSize(2);
+        assertThat(result.get("schemaa")).containsExactlyInAnyOrder("table1", "table2");
+        assertThat(result.get("schemab")).containsExactlyInAnyOrder("table3");
+    }
+
+    @Test
+    void testParseSchemaTableGrouping_LowercasesForCaseInsensitiveMatching() {
+        String envVar = "SchemaA:TableOne";
+
+        Map<String, Set<String>> result = CommonUtil.parseSchemaTableGrouping(envVar);
+
+        assertThat(result).containsKey("schemaa");
+        assertThat(result.get("schemaa")).containsExactly("tableone");
+    }
+
+    @Test
+    void testParseSchemaTableGrouping_Null() {
+        assertThat(CommonUtil.parseSchemaTableGrouping(null)).isEmpty();
+    }
+
+    @Test
+    void testParseSchemaTableGrouping_Empty() {
+        assertThat(CommonUtil.parseSchemaTableGrouping("")).isEmpty();
+    }
+
+    @Test
+    void testParseSchemaTableGrouping_InvalidEntriesSkipped() {
+        String envVar = "schemaA:table1,invalid_entry,:table2,schemaB:";
+
+        Map<String, Set<String>> result = CommonUtil.parseSchemaTableGrouping(envVar);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get("schemaa")).containsExactly("table1");
+    }
+
+    @Test
+    void testIsTableAccessAllowed_NoWhitelistOrBlacklist_Allowed() {
+        boolean result = CommonUtil.isTableAccessAllowed("schemaa", "table1", Collections.emptyMap(), Collections.emptyMap());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testIsTableAccessAllowed_SchemaNotInWhitelist_Unrestricted() {
+        // Only schemaB is whitelisted; schemaA has no entries, so it's unrestricted by the whitelist.
+        Map<String, Set<String>> whitelist = Map.of("schemab", Set.of("table9"));
+
+        boolean result = CommonUtil.isTableAccessAllowed("schemaa", "table1", whitelist, Collections.emptyMap());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testIsTableAccessAllowed_TableInWhitelistedSchemaAndInList_Allowed() {
+        Map<String, Set<String>> whitelist = Map.of("schemaa", Set.of("table1", "table2"));
+
+        boolean result = CommonUtil.isTableAccessAllowed("schemaa", "table1", whitelist, Collections.emptyMap());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void testIsTableAccessAllowed_TableInWhitelistedSchemaButNotInList_Blocked() {
+        Map<String, Set<String>> whitelist = Map.of("schemaa", Set.of("table1", "table2"));
+
+        boolean result = CommonUtil.isTableAccessAllowed("schemaa", "table3", whitelist, Collections.emptyMap());
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testIsTableAccessAllowed_TableBlacklisted_Blocked() {
+        Map<String, Set<String>> blacklist = Map.of("schemaa", Set.of("table1"));
+
+        boolean result = CommonUtil.isTableAccessAllowed("schemaa", "table1", Collections.emptyMap(), blacklist);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testIsTableAccessAllowed_BlacklistWinsOverWhitelist() {
+        // A table that's both whitelisted and blacklisted must be blocked - deny wins.
+        Map<String, Set<String>> whitelist = Map.of("schemaa", Set.of("table1"));
+        Map<String, Set<String>> blacklist = Map.of("schemaa", Set.of("table1"));
+
+        boolean result = CommonUtil.isTableAccessAllowed("schemaa", "table1", whitelist, blacklist);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void testIsTableAccessAllowed_CaseInsensitiveMatching() {
+        Map<String, Set<String>> whitelist = Map.of("schemaa", Set.of("table1"));
+
+        boolean result = CommonUtil.isTableAccessAllowed("SchemaA", "Table1", whitelist, Collections.emptyMap());
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
     void testAddReservedFields_NoExisting() {
         // Arrange
         Schema originalSchema = new Schema(Collections.emptyList());

--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/BaseLarkBaseCrawlerHandler.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/BaseLarkBaseCrawlerHandler.java
@@ -358,11 +358,37 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
     }
 
     /**
+     * Filters the tables discovered in Lark for a database down to those allowed by that database's
+     * whitelist/blacklist configuration (read from the control table's "whitelist_tables"/"blacklist_tables"
+     * columns). The blacklist always wins; the whitelist only restricts a database that has at least one
+     * whitelist entry.
+     *
+     * @param tables The tables discovered in Lark for this database.
+     * @param recordItem The control-table record for this database, carrying its whitelist/blacklist table IDs.
+     * @return The filtered list of tables allowed to be crawled.
+     */
+    private List<ListAllTableResponse.BaseItem> filterTablesByAccessControl(List<ListAllTableResponse.BaseItem> tables,
+                                                                            LarkDatabaseRecord recordItem)
+    {
+        Set<String> blacklistTableIds = recordItem.blacklistTableIds();
+        Set<String> whitelistTableIds = recordItem.whitelistTableIds();
+
+        return tables.stream()
+                .filter(table -> blacklistTableIds == null || blacklistTableIds.isEmpty()
+                        || !blacklistTableIds.contains(table.getTableId()))
+                .filter(table -> whitelistTableIds == null || whitelistTableIds.isEmpty()
+                        || whitelistTableIds.contains(table.getTableId()))
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Create Tables for New Databases
      *
      * @param databaseToCreate The database to create
+     * @param recordsByDatabaseName The control-table record for each database being created, keyed by database name
      */
-    private void createTablesForNewDatabases(Map<String, String> databaseToCreate)
+    private void createTablesForNewDatabases(Map<String, String> databaseToCreate,
+                                             Map<String, LarkDatabaseRecord> recordsByDatabaseName)
     {
         Map<String, List<TableInput>> batchCreateTableRequest = new HashMap<>();
 
@@ -374,6 +400,10 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
             List<TableInput> tableInputs = new ArrayList<>();
 
             List<ListAllTableResponse.BaseItem> listTables = larkBaseService.listTables(databaseId);
+            LarkDatabaseRecord recordItem = recordsByDatabaseName.get(databaseName);
+            if (recordItem != null) {
+                listTables = filterTablesByAccessControl(listTables, recordItem);
+            }
 
             for (ListAllTableResponse.BaseItem tableItem : listTables) {
                 TableInput newTableInput = this.constructNewTables(databaseId, tableItem.getTableId(), tableItem.getName());
@@ -406,6 +436,7 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
                                                       List<LarkDatabaseRecord> databaseFromLark)
     {
         Map<String, String> databaseToCreate = new HashMap<>();
+        Map<String, LarkDatabaseRecord> recordsByDatabaseName = new HashMap<>();
         Set<String> existingDatabaseNames = databasesFromCatalog.stream()
                 .map(Database::name)
                 .collect(Collectors.toSet());
@@ -417,6 +448,7 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
             if (!existingDatabaseNames.contains(recordItem.name())) {
                 databaseToCreate.put(recordItem.name(), Util.constructDatabaseLocationURI(
                         getCrawlingMethod(), getCrawlingSource(), recordItem.id()));
+                recordsByDatabaseName.put(recordItem.name(), recordItem);
                 logger.info("Marking database for creation: {}, locationUri: {}",
                         recordItem.name(), Util.constructDatabaseLocationURIPrefix(
                                 getCrawlingMethod(), getCrawlingSource()
@@ -440,7 +472,7 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
 
             // Step 4.1: Create tables for new databases
             logger.info("Step 4.1: Creating tables for new databases");
-            this.createTablesForNewDatabases(databaseToCreate);
+            this.createTablesForNewDatabases(databaseToCreate, recordsByDatabaseName);
             logger.info("Step 4.1: Tables created successfully");
         }
         else {
@@ -552,7 +584,8 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
         logger.info("Step 5.2.1: Found {} tables in Glue for database: {}", originalExistingTables.size(), database.name());
 
         logger.info("Step 5.2.2: Getting tables from Lark");
-        List<ListAllTableResponse.BaseItem> larkTables = larkBaseService.listTables(recordItem.id());
+        List<ListAllTableResponse.BaseItem> larkTables = filterTablesByAccessControl(
+                larkBaseService.listTables(recordItem.id()), recordItem);
         logger.info("Step 5.2.2: Found {} tables in Lark for database: {}", larkTables.size(), database.name());
 
         Map<String, String> larkTableNameMap = new HashMap<>();

--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/model/LarkDatabaseRecord.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/model/LarkDatabaseRecord.java
@@ -19,9 +19,23 @@
  */
 package com.amazonaws.glue.lark.base.crawler.model;
 
+import java.util.Collections;
+import java.util.Set;
+
 /**
  * Record for Lark Database Record
  * @param id The database ID
  * @param name The database name
+ * @param whitelistTableIds Lark table IDs to exclusively crawl for this database, from the control table's
+ *                          "whitelist_tables" column. If empty, all tables in this database are crawled
+ *                          (subject to blacklistTableIds).
+ * @param blacklistTableIds Lark table IDs to always exclude from crawling for this database, from the control
+ *                          table's "blacklist_tables" column. Takes precedence over whitelistTableIds.
  */
-public record LarkDatabaseRecord(String id, String name) {}
+public record LarkDatabaseRecord(String id, String name, Set<String> whitelistTableIds, Set<String> blacklistTableIds)
+{
+    public LarkDatabaseRecord(String id, String name)
+    {
+        this(id, name, Collections.emptySet(), Collections.emptySet());
+    }
+}

--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/service/LarkBaseService.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/service/LarkBaseService.java
@@ -36,9 +36,11 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -262,6 +264,8 @@ public class LarkBaseService extends CommonLarkService
 
                             String id = null;
                             String name = null;
+                            Set<String> whitelistTableIds = Collections.emptySet();
+                            Set<String> blacklistTableIds = Collections.emptySet();
 
                             if (fields != null) {
                                 if (fields.containsKey("id")) {
@@ -273,9 +277,15 @@ public class LarkBaseService extends CommonLarkService
                                     Object nameObj = fields.get("name");
                                     name = nameObj != null ? nameObj.toString() : null;
                                 }
+
+                                // Optional columns on the control table: comma-separated Lark table IDs that
+                                // restrict which tables get crawled for this database. Absent/blank means no
+                                // restriction from that list.
+                                whitelistTableIds = parseTableIdList(fields.get("whitelist_tables"));
+                                blacklistTableIds = parseTableIdList(fields.get("blacklist_tables"));
                             }
 
-                            parsedRecords.add(new LarkDatabaseRecord(id, name));
+                            parsedRecords.add(new LarkDatabaseRecord(id, name, whitelistTableIds, blacklistTableIds));
                         }
                     }
 
@@ -297,6 +307,30 @@ public class LarkBaseService extends CommonLarkService
     }
 
     /**
+     * Parses a comma-separated list of Lark table IDs from a raw control-table cell value into a Set.
+     * Returns an empty set (meaning "no restriction from this list") for a null, blank, or unparseable value.
+     *
+     * @param rawValue The raw cell value from the control table (expected to be a String).
+     * @return A set of trimmed, non-empty table IDs.
+     */
+    private Set<String> parseTableIdList(Object rawValue)
+    {
+        if (rawValue == null) {
+            return Collections.emptySet();
+        }
+
+        String rawString = rawValue.toString();
+        if (rawString.isBlank()) {
+            return Collections.emptySet();
+        }
+
+        return Arrays.stream(rawString.split(","))
+                .map(String::trim)
+                .filter(tableId -> !tableId.isEmpty())
+                .collect(Collectors.toSet());
+    }
+
+    /**
      * Sanitize records.
      *
      * @param records The list of records
@@ -308,7 +342,7 @@ public class LarkBaseService extends CommonLarkService
                 .map(record -> {
                     String sanitizedId = record.id();
                     String sanitizedName = Util.sanitizeGlueRelatedName(record.name());
-                    return new LarkDatabaseRecord(sanitizedId, sanitizedName);
+                    return new LarkDatabaseRecord(sanitizedId, sanitizedName, record.whitelistTableIds(), record.blacklistTableIds());
                 })
                 .collect(Collectors.toList());
 

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/LarkBaseCrawlerHandlerTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/LarkBaseCrawlerHandlerTest.java
@@ -210,6 +210,79 @@ public class LarkBaseCrawlerHandlerTest {
     }
 
     @Test
+    public void testHandleRequest_newDatabaseWithBlacklistedTable_tableNotCreated() {
+        // Lark has 2 tables, but one is blacklisted on the control-table record for this database.
+        LarkDatabaseRecord larkDb = new LarkDatabaseRecord("dbId1", "new_db",
+                Collections.emptySet(), java.util.Set.of("tableId2"));
+        ListAllTableResponse.BaseItem allowedTable = ListAllTableResponse.BaseItem.builder().tableId("tableId1").name("allowed_table").build();
+        ListAllTableResponse.BaseItem blacklistedTable = ListAllTableResponse.BaseItem.builder().tableId("tableId2").name("blacklisted_table").build();
+
+        when(mockLarkBaseService.getTableRecords("baseDs123", "tableDs456")).thenReturn(Collections.singletonList(larkDb));
+        when(mockGlueCatalogService.getDatabases()).thenReturn(Collections.emptyList());
+        when(mockLarkBaseService.listTables("dbId1")).thenReturn(java.util.List.of(allowedTable, blacklistedTable));
+        when(mockLarkBaseService.getTableFields(anyString(), anyString())).thenReturn(Collections.emptyList());
+
+        String result = handler.handleRequest(payload, mockContext);
+        assertEquals("Success", result);
+
+        org.mockito.ArgumentCaptor<Map<String, List<software.amazon.awssdk.services.glue.model.TableInput>>> captor =
+                org.mockito.ArgumentCaptor.forClass(Map.class);
+        verify(mockGlueCatalogService, times(1)).batchCreateTable(captor.capture());
+
+        List<software.amazon.awssdk.services.glue.model.TableInput> createdTables = captor.getValue().get("new_db");
+        assertEquals(1, createdTables.size());
+        assertEquals("allowed_table", createdTables.get(0).name());
+    }
+
+    @Test
+    public void testHandleRequest_newDatabaseWithWhitelist_onlyWhitelistedTableCreated() {
+        LarkDatabaseRecord larkDb = new LarkDatabaseRecord("dbId1", "new_db",
+                java.util.Set.of("tableId1"), Collections.emptySet());
+        ListAllTableResponse.BaseItem whitelistedTable = ListAllTableResponse.BaseItem.builder().tableId("tableId1").name("whitelisted_table").build();
+        ListAllTableResponse.BaseItem otherTable = ListAllTableResponse.BaseItem.builder().tableId("tableId2").name("other_table").build();
+
+        when(mockLarkBaseService.getTableRecords("baseDs123", "tableDs456")).thenReturn(Collections.singletonList(larkDb));
+        when(mockGlueCatalogService.getDatabases()).thenReturn(Collections.emptyList());
+        when(mockLarkBaseService.listTables("dbId1")).thenReturn(java.util.List.of(whitelistedTable, otherTable));
+        when(mockLarkBaseService.getTableFields(anyString(), anyString())).thenReturn(Collections.emptyList());
+
+        String result = handler.handleRequest(payload, mockContext);
+        assertEquals("Success", result);
+
+        org.mockito.ArgumentCaptor<Map<String, List<software.amazon.awssdk.services.glue.model.TableInput>>> captor =
+                org.mockito.ArgumentCaptor.forClass(Map.class);
+        verify(mockGlueCatalogService, times(1)).batchCreateTable(captor.capture());
+
+        List<software.amazon.awssdk.services.glue.model.TableInput> createdTables = captor.getValue().get("new_db");
+        assertEquals(1, createdTables.size());
+        assertEquals("whitelisted_table", createdTables.get(0).name());
+    }
+
+    @Test
+    public void testHandleRequest_existingTableNewlyBlacklisted_getsDeleted() {
+        // A table that was previously crawled is now blacklisted on the control-table record; it must be
+        // removed from Glue on the next crawl, the same as if it no longer existed in Lark at all.
+        LarkDatabaseRecord larkDb = new LarkDatabaseRecord("dbId1", "db_name",
+                Collections.emptySet(), java.util.Set.of("tableId1"));
+        Database glueDb = Database.builder().name("db_name")
+                .locationUri("lark-base-flag/CrawlingMethod=LarkBase/DataSource=baseDs123:tableDs456/Base=dbId1").build();
+        Table glueTable = Table.builder().name("now_blacklisted_table").databaseName("db_name").build();
+        ListAllTableResponse.BaseItem larkTable = ListAllTableResponse.BaseItem.builder().tableId("tableId1").name("now_blacklisted_table").build();
+
+        when(mockLarkBaseService.getTableRecords(anyString(), anyString())).thenReturn(Collections.singletonList(larkDb));
+        when(mockGlueCatalogService.getDatabases()).thenReturn(Collections.singletonList(glueDb));
+        when(mockGlueCatalogService.getTables("db_name")).thenReturn(Collections.singletonList(glueTable));
+        when(mockLarkBaseService.listTables("dbId1")).thenReturn(Collections.singletonList(larkTable));
+
+        String result = handler.handleRequest(payload, mockContext);
+        assertEquals("Success", result);
+
+        verify(mockGlueCatalogService, times(1)).batchDeleteTable(any());
+        verify(mockGlueCatalogService, never()).batchCreateTable(any());
+        verify(mockGlueCatalogService, never()).batchUpdateTable(any());
+    }
+
+    @Test
     public void testHandleRequest_withDatabaseDeletion() {
         // Glue memiliki 1 DB, Lark kosong
         Database glueDb = Database.builder().name("old_db")

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/model/LarkDatabaseRecordTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/model/LarkDatabaseRecordTest.java
@@ -20,6 +20,10 @@
 package com.amazonaws.glue.lark.base.crawler.model;
 
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
 import static org.junit.Assert.*;
 
 public class LarkDatabaseRecordTest {
@@ -43,5 +47,24 @@ public class LarkDatabaseRecordTest {
         assertEquals(record1a, record1b);
         assertNotEquals(record1a, record2);
         assertEquals(record1a.hashCode(), record1b.hashCode());
+    }
+
+    @Test
+    public void twoArgConstructor_defaultsWhitelistAndBlacklistToEmpty() {
+        LarkDatabaseRecord record = new LarkDatabaseRecord("id1", "name1");
+
+        assertEquals(Collections.emptySet(), record.whitelistTableIds());
+        assertEquals(Collections.emptySet(), record.blacklistTableIds());
+    }
+
+    @Test
+    public void fourArgConstructor_shouldHoldWhitelistAndBlacklistValues() {
+        Set<String> whitelist = Set.of("tbl1", "tbl2");
+        Set<String> blacklist = Set.of("tbl3");
+
+        LarkDatabaseRecord record = new LarkDatabaseRecord("id1", "name1", whitelist, blacklist);
+
+        assertEquals(whitelist, record.whitelistTableIds());
+        assertEquals(blacklist, record.blacklistTableIds());
     }
 }

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/service/LarkBaseServiceTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/service/LarkBaseServiceTest.java
@@ -43,6 +43,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -204,6 +205,58 @@ public class LarkBaseServiceTest {
         assertEquals("rec123", result.get(0).id());
         assertEquals("record_name", result.get(0).name());
         verify(larkBaseService, times(1)).refreshTenantAccessToken();
+    }
+
+    @Test
+    public void getTableRecords_success_withWhitelistAndBlacklistColumns() throws Exception {
+        String baseId = "baseR1";
+        String tableId = "tblR1";
+        String mockJsonResponse = "{\"code\":0,\"data\":{\"items\":[{\"record_id\":\"rec123\",\"fields\":{"
+                + "\"id\":\"rec123\",\"name\":\"Record Name\","
+                + "\"whitelist_tables\":\"tblA, tblB ,tblC\","
+                + "\"blacklist_tables\":\"tblD\"}}],\"has_more\":false}}";
+
+        when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+        when(mockHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(mockJsonResponse.getBytes()));
+
+        List<LarkDatabaseRecord> result = larkBaseService.getTableRecords(baseId, tableId);
+
+        assertEquals(1, result.size());
+        assertEquals(Set.of("tblA", "tblB", "tblC"), result.get(0).whitelistTableIds());
+        assertEquals(Set.of("tblD"), result.get(0).blacklistTableIds());
+    }
+
+    @Test
+    public void getTableRecords_success_withoutWhitelistOrBlacklistColumns_defaultsToEmpty() throws Exception {
+        String baseId = "baseR1";
+        String tableId = "tblR1";
+        String mockJsonResponse = "{\"code\":0,\"data\":{\"items\":[{\"record_id\":\"rec123\",\"fields\":{"
+                + "\"id\":\"rec123\",\"name\":\"Record Name\"}}],\"has_more\":false}}";
+
+        when(mockHttpClient.execute(any(HttpPost.class))).thenReturn(mockHttpResponse);
+        when(mockHttpResponse.getEntity()).thenReturn(mockHttpEntity);
+        when(mockHttpEntity.getContent()).thenReturn(new ByteArrayInputStream(mockJsonResponse.getBytes()));
+
+        List<LarkDatabaseRecord> result = larkBaseService.getTableRecords(baseId, tableId);
+
+        assertEquals(1, result.size());
+        assertEquals(Collections.emptySet(), result.get(0).whitelistTableIds());
+        assertEquals(Collections.emptySet(), result.get(0).blacklistTableIds());
+    }
+
+    @Test
+    public void sanitizeRecords_preservesWhitelistAndBlacklistTableIds() {
+        Set<String> whitelist = Set.of("tblA");
+        Set<String> blacklist = Set.of("tblB");
+        List<LarkDatabaseRecord> records = Collections.singletonList(
+                new LarkDatabaseRecord("id1", "Record One", whitelist, blacklist)
+        );
+
+        List<LarkDatabaseRecord> sanitized = larkBaseService.sanitizeRecords(records);
+
+        assertEquals(whitelist, sanitized.get(0).whitelistTableIds());
+        assertEquals(blacklist, sanitized.get(0).blacklistTableIds());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Adds table-level access control, with two independent mechanisms depending on which component is running:

- **Connector (Lambda)**: new `WHITELIST_TABLES` / `BLACKLIST_TABLES` environment variables, format `schemaName:tableName,...`. Applies uniformly on top of whichever metadata discovery path is active (Glue, Lark Base Source, Drive Source, Experimental). A schema with no whitelist entries is unrestricted; blacklist always wins. Enforcement is a full block - disallowed tables disappear from `SHOW TABLES` and a direct `SELECT`/`DESCRIBE` fails as if the table doesn't exist.
- **Crawler**: reads whitelist/blacklist directly from Lark Base. The crawler's existing per-database control table gets two new optional columns, `whitelist_tables` and `blacklist_tables` (comma-separated Lark table IDs, not names, so it survives renames). A table that gets blacklisted after already being crawled is removed from Glue on the next run.

## Test plan

- [x] Full test suite passes for both modules (`mvn test`)
- [x] Checkstyle passes for both modules
- [x] New unit tests for the parsing/filtering logic, the connector's `doListTables`/`doGetTable` enforcement, and the crawler's create/update/delete flows (including a table going from allowed to blacklisted between crawl runs)