### PR TITLE
Fix OR'd range predicate pushdown being combined as AND

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -852,6 +852,18 @@ All tables automatically include these fields:
 - Complex types (ATTACHMENT, PERSON, etc.)
 - FORMULA fields
 
+**IN-clauses and OR'd ranges**: Lark's Search API has no native "in" operator and its `is`/`isNot`
+operators accept only one value each, so a multi-value IN-clause (`WHERE x IN (a, b)`) and a multi-range
+union on one column (`WHERE x < 5 OR x > 100`, or `x != 5` when modeled internally as two disjoint ranges)
+are both pushed down as an OR-group nested under the top-level AND via `children`, matching Lark's filter
+guide. `NOT IN` is unaffected - ANDing multiple `isNot` conditions is already correct. A union containing a
+range that needs both bounds (e.g. a BETWEEN mixed into the union) can't be expressed this way, since Lark
+supports only one level of `children` nesting with a single conjunction per group ("OR of ANDs" would need
+two levels) - that case is skipped entirely and left to Athena's client-side filtering rather than risk
+pushing down an incorrect result. Verified against Lark's live Search Records API: `x < 1 OR x > 200000000`
+correctly matched the expected rows, while `x < 1 AND x > 200000000` (the flattened equivalent) always
+matched zero rows.
+
 **Example**:
 ```sql
 -- SQL Query

--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslator.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslator.java
@@ -104,6 +104,29 @@ public final class SearchApiFilterTranslator
                 orGroup.put("conditions", orConditions);
                 orGroups.add(orGroup);
             }
+            // A SortedRangeSet with more than one Range represents a UNION of ranges for this single column
+            // (per the SDK's own definition: "col between 10 and 30, or col between 40 and 60, ..."), e.g.
+            // "x < 5 OR x > 100", or "x != 5" (modeled as two disjoint ranges excluding the single point).
+            // translateRangeSet's per-range loop would otherwise flatten every range's conditions into the
+            // same top-level AND list - the exact same class of bug as the IN-clause case above, just for
+            // ranges instead of discrete values. Route it into an OR-group instead when it's safely
+            // expressible that way (see buildRangeUnionOrGroup for when it isn't).
+            else if (valueSet instanceof SortedRangeSet rangeSet && !isSingleValueSafe(rangeSet)
+                    && getOrderedRangesSafe(rangeSet, fieldName).size() > 1) {
+                List<Range> ranges = getOrderedRangesSafe(rangeSet, fieldName);
+                List<Map<String, Object>> orConditions = buildRangeUnionOrGroup(fieldName, ranges, fieldUiType);
+                if (orConditions != null) {
+                    Map<String, Object> orGroup = new HashMap<>();
+                    orGroup.put("conjunction", "or");
+                    orGroup.put("conditions", orConditions);
+                    orGroups.add(orGroup);
+                }
+                else {
+                    logger.info("Skipping pushdown for column '{}': multi-range union includes a range needing "
+                            + "both bounds (e.g. BETWEEN), which Lark's filter API can't express as an OR "
+                            + "without unsupported nested grouping. Falling back to client-side filtering.", fieldName);
+                }
+            }
             else {
                 List<Map<String, Object>> conditions = translateValueSetToConditions(fieldName, valueSet, fieldUiType);
                 allConditions.addAll(conditions);
@@ -128,6 +151,37 @@ public final class SearchApiFilterTranslator
         catch (Exception e) {
             logger.error("Failed to serialize filter to JSON: {}", e.getMessage(), e);
             return "";
+        }
+    }
+
+    /**
+     * Safely checks {@link SortedRangeSet#isSingleValue()}, treating any exception (e.g. from a malformed or
+     * mocked ValueSet) as "not a single value" so the caller falls through to the general per-field error
+     * handling instead of letting the exception escape {@link #toFilterJson}.
+     */
+    private static boolean isSingleValueSafe(SortedRangeSet rangeSet)
+    {
+        try {
+            return rangeSet.isSingleValue();
+        }
+        catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Safely retrieves the ordered ranges from a SortedRangeSet, returning an empty list (instead of letting
+     * the exception escape {@link #toFilterJson}) if the underlying ValueSet throws.
+     */
+    private static List<Range> getOrderedRangesSafe(SortedRangeSet rangeSet, String fieldName)
+    {
+        try {
+            List<Range> ranges = rangeSet.getRanges().getOrderedRanges();
+            return ranges != null ? ranges : Collections.emptyList();
+        }
+        catch (Exception e) {
+            logger.warn("Error retrieving ranges for field '{}': {}", fieldName, e.getMessage());
+            return Collections.emptyList();
         }
     }
 
@@ -228,30 +282,73 @@ public final class SearchApiFilterTranslator
             }
         }
 
-        // Handle ranges (>, <, >= , <= )
+        // Handle a single range (>, <, >=, <=, or BETWEEN via both bounds set). Callers (toFilterJson) route
+        // SortedRangeSets with more than one Range to buildRangeUnionOrGroup instead, since multiple ranges
+        // are a union (OR) that a flat AND list here would translate incorrectly - see toFilterJson.
         try {
             List<Range> ranges = rangeSet.getRanges().getOrderedRanges();
-            if (ranges != null) {
-                for (Range range : ranges) {
-                    Marker low = range.getLow();
-                    Marker high = range.getHigh();
-
-                    if (!low.isLowerUnbounded()) {
-                        String operator = (low.getBound() == Marker.Bound.EXACTLY) ? "isGreaterEqual" : "isGreater";
-                        Object value = convertValueForSearchApi(low.getValue(), fieldUiType);
-                        conditions.add(createCondition(fieldName, operator, value));
-                    }
-
-                    if (!high.isUpperUnbounded()) {
-                        String operator = (high.getBound() == Marker.Bound.EXACTLY) ? "isLessEqual" : "isLess";
-                        Object value = convertValueForSearchApi(high.getValue(), fieldUiType);
-                        conditions.add(createCondition(fieldName, operator, value));
-                    }
-                }
+            if (ranges != null && ranges.size() == 1) {
+                addRangeBoundConditions(conditions, fieldName, ranges.get(0), fieldUiType);
             }
         }
         catch (Exception e) {
             logger.warn("Error processing ranges for field '{}': {}", fieldName, e.getMessage());
+        }
+
+        return conditions;
+    }
+
+    /**
+     * Appends the low/high bound conditions for a single Range (e.g. {@code isGreater}/{@code isLessEqual}) to
+     * the given conditions list. A range with both bounds set (e.g. BETWEEN) appends both conditions, which the
+     * caller must AND together for correctness.
+     */
+    private static void addRangeBoundConditions(List<Map<String, Object>> conditions, String fieldName, Range range, UITypeEnum fieldUiType)
+    {
+        Marker low = range.getLow();
+        Marker high = range.getHigh();
+
+        if (!low.isLowerUnbounded()) {
+            String operator = (low.getBound() == Marker.Bound.EXACTLY) ? "isGreaterEqual" : "isGreater";
+            Object value = convertValueForSearchApi(low.getValue(), fieldUiType);
+            conditions.add(createCondition(fieldName, operator, value));
+        }
+
+        if (!high.isUpperUnbounded()) {
+            String operator = (high.getBound() == Marker.Bound.EXACTLY) ? "isLessEqual" : "isLess";
+            Object value = convertValueForSearchApi(high.getValue(), fieldUiType);
+            conditions.add(createCondition(fieldName, operator, value));
+        }
+    }
+
+    /**
+     * Builds the conditions for an OR-group representing a union of multiple ranges on one column (e.g.
+     * {@code x < 5 OR x > 100}, or {@code x != 5} modeled as two disjoint ranges excluding a single point).
+     * Lark's filter API supports only one level of "children" nesting with a single conjunction per group, so
+     * this can only be expressed correctly when every range needs just one condition (single-bounded). A range
+     * needing both bounds ANDed together (e.g. BETWEEN) mixed into a union would require "OR of ANDs", which
+     * needs two levels of nesting - not supported.
+     *
+     * @return The OR-group's conditions (one per range), or null if the union isn't safely expressible this way.
+     */
+    private static List<Map<String, Object>> buildRangeUnionOrGroup(String fieldName, List<Range> ranges, UITypeEnum fieldUiType)
+    {
+        boolean allSingleBounded = ranges.stream()
+                .allMatch(range -> range.getLow().isLowerUnbounded() != range.getHigh().isUpperUnbounded());
+
+        if (!allSingleBounded) {
+            return null;
+        }
+
+        List<Map<String, Object>> conditions = new ArrayList<>();
+        try {
+            for (Range range : ranges) {
+                addRangeBoundConditions(conditions, fieldName, range, fieldUiType);
+            }
+        }
+        catch (Exception e) {
+            logger.warn("Error processing range union for field '{}': {}", fieldName, e.getMessage());
+            return null;
         }
 
         return conditions;

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslatorTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/SearchApiFilterTranslatorTest.java
@@ -534,6 +534,122 @@ public class SearchApiFilterTranslatorTest {
     }
 
     @Test
+    public void testToFilterJson_withSortedRangeSet_multiRangeUnion_pushedDownAsOrGroup() throws Exception {
+        // WHERE field_number < 5 OR field_number > 100 - Presto/Trino models this as a single SortedRangeSet
+        // with two disjoint, single-bounded ranges (per the SDK's own definition of SortedRangeSet: "col
+        // between 10 and 30, or col between 40 and 60, ..."). Flattening both ranges' conditions into the
+        // same top-level AND list (the pre-fix behavior) would produce "field_number < 5 AND field_number >
+        // 100", which can never match anything. It must instead become an OR-group.
+        SortedRangeSet valueSet = mock(SortedRangeSet.class);
+        when(valueSet.isSingleValue()).thenReturn(false);
+        when(valueSet.isNullAllowed()).thenReturn(true);
+        when(valueSet.getType()).thenReturn(new ArrowType.Int(32, true));
+
+        Ranges ranges = mock(Ranges.class);
+
+        Range lessThanFive = mock(Range.class);
+        Marker lessThanFiveLow = mock(Marker.class);
+        Marker lessThanFiveHigh = mock(Marker.class);
+        when(lessThanFiveLow.isLowerUnbounded()).thenReturn(true);
+        when(lessThanFiveHigh.isUpperUnbounded()).thenReturn(false);
+        when(lessThanFiveHigh.getBound()).thenReturn(Marker.Bound.BELOW);
+        when(lessThanFiveHigh.getValue()).thenReturn(5);
+        when(lessThanFive.getLow()).thenReturn(lessThanFiveLow);
+        when(lessThanFive.getHigh()).thenReturn(lessThanFiveHigh);
+
+        Range greaterThanHundred = mock(Range.class);
+        Marker greaterThanHundredLow = mock(Marker.class);
+        Marker greaterThanHundredHigh = mock(Marker.class);
+        when(greaterThanHundredLow.isLowerUnbounded()).thenReturn(false);
+        when(greaterThanHundredLow.getBound()).thenReturn(Marker.Bound.ABOVE);
+        when(greaterThanHundredLow.getValue()).thenReturn(100);
+        when(greaterThanHundredHigh.isUpperUnbounded()).thenReturn(true);
+        when(greaterThanHundred.getLow()).thenReturn(greaterThanHundredLow);
+        when(greaterThanHundred.getHigh()).thenReturn(greaterThanHundredHigh);
+
+        when(ranges.getOrderedRanges()).thenReturn(Arrays.asList(lessThanFive, greaterThanHundred));
+        when(valueSet.getRanges()).thenReturn(ranges);
+
+        Map<String, ValueSet> constraints = new HashMap<>();
+        constraints.put("field_number", valueSet);
+
+        List<AthenaFieldLarkBaseMapping> mappings = Collections.singletonList(
+            new AthenaFieldLarkBaseMapping("field_number", "Number Field",
+                new NestedUIType(UITypeEnum.NUMBER, null)));
+
+        String filterJson = SearchApiFilterTranslator.toFilterJson(constraints, mappings);
+
+        assertNotNull(filterJson);
+        JsonNode filter = OBJECT_MAPPER.readTree(filterJson);
+        // No top-level AND conditions for this field - it must live entirely inside the OR-group.
+        assertEquals(0, filter.get("conditions").size());
+
+        JsonNode children = filter.get("children");
+        assertEquals(1, children.size());
+        JsonNode orGroup = children.get(0);
+        assertEquals("or", orGroup.get("conjunction").asText());
+        JsonNode orConditions = orGroup.get("conditions");
+        assertEquals(2, orConditions.size());
+        assertEquals("isLess", orConditions.get(0).get("operator").asText());
+        assertEquals("5", orConditions.get(0).get("value").get(0).asText());
+        assertEquals("isGreater", orConditions.get(1).get("operator").asText());
+        assertEquals("100", orConditions.get(1).get("value").get(0).asText());
+    }
+
+    @Test
+    public void testToFilterJson_withSortedRangeSet_multiRangeUnionWithDoubleBoundedRange_skipsPushdown() throws Exception {
+        // A union containing a range that needs BOTH bounds (e.g. one BETWEEN-shaped range OR'd with a
+        // single-bounded range) can't be expressed within Lark's one-level-of-nesting filter API (it would
+        // require "OR of ANDs"). It must be skipped entirely rather than pushed down incorrectly.
+        SortedRangeSet valueSet = mock(SortedRangeSet.class);
+        when(valueSet.isSingleValue()).thenReturn(false);
+        when(valueSet.isNullAllowed()).thenReturn(true);
+        when(valueSet.getType()).thenReturn(new ArrowType.Int(32, true));
+
+        Ranges ranges = mock(Ranges.class);
+
+        // First range: BETWEEN 10 AND 20 (both bounds set).
+        Range between = mock(Range.class);
+        Marker betweenLow = mock(Marker.class);
+        Marker betweenHigh = mock(Marker.class);
+        when(betweenLow.isLowerUnbounded()).thenReturn(false);
+        when(betweenLow.getBound()).thenReturn(Marker.Bound.EXACTLY);
+        when(betweenLow.getValue()).thenReturn(10);
+        when(betweenHigh.isUpperUnbounded()).thenReturn(false);
+        when(betweenHigh.getBound()).thenReturn(Marker.Bound.EXACTLY);
+        when(betweenHigh.getValue()).thenReturn(20);
+        when(between.getLow()).thenReturn(betweenLow);
+        when(between.getHigh()).thenReturn(betweenHigh);
+
+        // Second range: > 100 (single-bounded).
+        Range greaterThanHundred = mock(Range.class);
+        Marker greaterThanHundredLow = mock(Marker.class);
+        Marker greaterThanHundredHigh = mock(Marker.class);
+        when(greaterThanHundredLow.isLowerUnbounded()).thenReturn(false);
+        when(greaterThanHundredLow.getBound()).thenReturn(Marker.Bound.ABOVE);
+        when(greaterThanHundredLow.getValue()).thenReturn(100);
+        when(greaterThanHundredHigh.isUpperUnbounded()).thenReturn(true);
+        when(greaterThanHundred.getLow()).thenReturn(greaterThanHundredLow);
+        when(greaterThanHundred.getHigh()).thenReturn(greaterThanHundredHigh);
+
+        when(ranges.getOrderedRanges()).thenReturn(Arrays.asList(between, greaterThanHundred));
+        when(valueSet.getRanges()).thenReturn(ranges);
+
+        Map<String, ValueSet> constraints = new HashMap<>();
+        constraints.put("field_number", valueSet);
+
+        List<AthenaFieldLarkBaseMapping> mappings = Collections.singletonList(
+            new AthenaFieldLarkBaseMapping("field_number", "Number Field",
+                new NestedUIType(UITypeEnum.NUMBER, null)));
+
+        String filterJson = SearchApiFilterTranslator.toFilterJson(constraints, mappings);
+
+        // Not pushed down at all - correctness over optimization when it can't be expressed safely.
+        assertNotNull(filterJson);
+        assertEquals("", filterJson);
+    }
+
+    @Test
     public void testToFilterJson_withEquatableValueSet_whitelist() throws Exception {
         // Mock EquatableValueSet with whitelist (IN clause)
         EquatableValueSet valueSet = mock(EquatableValueSet.class);


### PR DESCRIPTION
## Summary

Found while double-checking predicate pushdown correctness. `SortedRangeSet` (used for any comparison/range constraint - `<`, `>`, `BETWEEN`, `!=`) can hold more than one `Range` for a single column, and multiple ranges there mean OR/union, not AND - same underlying bug shape as the IN-clause fix from #21, just for ranges instead of discrete values.

The filter translator was flattening every range's conditions into one AND'd list. Concretely: `WHERE x < 5 OR x > 100` was being pushed to Lark as `x < 5 AND x > 100`, which can never match anything - so the query silently returned zero rows instead of the correct result. This also affects `x != 5` on comparable types, since that's commonly modeled internally as two disjoint ranges excluding the single point.

Fix: route multi-range unions into an OR-group (same `children` mechanism used for the IN-clause fix), when every range is single-bounded. A union that includes a range needing both bounds (e.g. one `BETWEEN` OR'd with something else) can't be expressed within Lark's filter API - it only supports one level of nesting - so that specific shape is skipped and left to Athena's client-side filtering rather than risk pushing down something wrong.

## Test plan

- [x] Full test suite passes, checkstyle passes
- [x] New unit tests covering the OR-group case and the "skip pushdown" fallback case
- [x] Verified directly against Lark's live Search Records API: `x < 1 OR x > 200000000` correctly returned the expected rows, while the flattened `x < 1 AND x > 200000000` equivalent always returned zero