### PR TITLE
Fix crawler writing duplicate Glue column names for colliding Lark field names

### DIFF
--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/util/Util.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/util/Util.java
@@ -32,7 +32,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.amazonaws.glue.lark.base.crawler.LarkBaseCrawlerConstants.CRAWLING_METHOD;
 import static com.amazonaws.glue.lark.base.crawler.LarkBaseCrawlerConstants.LARK_BASE_FLAG;
@@ -266,17 +265,31 @@ public final class Util
      */
     public static Collection<Column> constructColumns(ArrayList<ColumnParameters> params)
     {
-        return params.stream()
-                .map(param -> Column.builder()
-                        .name(param.getColumnName())
-                        .type(param.getColumnType())
-                        // Comment: LarkBaseId=<larkBaseId>/LarkBaseTableId=<larkTableId>/
-                        // LarkBaseFieldId=<larkBaseFieldId>/LarkBaseFieldName=<originalFieldName>/
-                        // LarkBaseFieldType=<larkBaseFieldType>
-                        // for larkBaseFieldType "Formula", we fill with "Formula<formula-type>"
-                        .comment(generateColumnComment(param))
-                        .build())
-                .collect(Collectors.toList());
+        // Two distinct Lark field names can sanitize down to the same Glue column name
+        // (e.g. "Segment 5" and "segment 5" both become "segment_5"). Glue allows writing
+        // duplicate column names into a table's StorageDescriptor, but the federation SDK's
+        // GlueMetadataHandler.doGetTable then throws (ImmutableMap.Builder rejects duplicate
+        // keys when building schema metadata from column names), breaking the whole table's
+        // schema resolution. Disambiguate collisions with the Lark field ID, which is unique.
+        Set<String> seenColumnNames = new HashSet<>();
+        List<Column> columns = new ArrayList<>();
+        for (ColumnParameters param : params) {
+            String columnName = param.getColumnName();
+            if (!seenColumnNames.add(columnName)) {
+                columnName = columnName + "_" + sanitizeGlueRelatedName(param.getLarkBaseRecordId());
+                seenColumnNames.add(columnName);
+            }
+            columns.add(Column.builder()
+                    .name(columnName)
+                    .type(param.getColumnType())
+                    // Comment: LarkBaseId=<larkBaseId>/LarkBaseTableId=<larkTableId>/
+                    // LarkBaseFieldId=<larkBaseFieldId>/LarkBaseFieldName=<originalFieldName>/
+                    // LarkBaseFieldType=<larkBaseFieldType>
+                    // for larkBaseFieldType "Formula", we fill with "Formula<formula-type>"
+                    .comment(generateColumnComment(param))
+                    .build());
+        }
+        return columns;
     }
 
     public static String generateColumnComment(ColumnParameters parameters)

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/util/UtilTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/util/UtilTest.java
@@ -123,6 +123,42 @@ class UtilTest {
     }
 
     @Test
+    void constructColumns_whenTwoFieldNamesSanitizeToSameGlueName_disambiguatesWithFieldId() {
+        // Reproduces a real production failure: two distinct Lark fields named "segment 5" and
+        // "Segment 5" both sanitize to the Glue column name "segment_5". Writing both as-is
+        // produces a Glue table with a duplicate column name, which later breaks the connector's
+        // whole doGetTable Glue fallback (SchemaBuilder rejects duplicate metadata keys) instead
+        // of just affecting the one field.
+        ArrayList<ColumnParameters> params = new ArrayList<>();
+        params.add(
+            ColumnParameters.builder()
+                    .columnName("segment 5")
+                    .columnType("string")
+                    .larkBaseFieldId("fldxdVXbHa")
+                    .larkBaseColumnType("Text")
+                    .larkBaseId("baseId456")
+                    .larkBaseTableId("tableId789")
+                    .build()
+        );
+        params.add(
+            ColumnParameters.builder()
+                    .columnName("Segment 5")
+                    .columnType("string")
+                    .larkBaseFieldId("fldZrayo2s")
+                    .larkBaseColumnType("Text")
+                    .larkBaseId("baseId456")
+                    .larkBaseTableId("tableId789")
+                    .build()
+        );
+
+        List<Column> columnList = new ArrayList<>(Util.constructColumns(params));
+        assertEquals(2, columnList.size());
+        assertEquals("segment_5", columnList.get(0).name());
+        assertEquals("segment_5_fldzrayo2s", columnList.get(1).name());
+        assertNotEquals(columnList.get(0).name(), columnList.get(1).name());
+    }
+
+    @Test
     void doesGlueDatabasesNameValid() {
         assertFalse(Util.doesGlueDatabasesNameValid(List.of("valid_name", "another_valid_123")));
         assertTrue(Util.doesGlueDatabasesNameValid(List.of("invalid-name")));


### PR DESCRIPTION
## Summary

Found while checking a production CloudWatch log for `interco_cross_posting.transaction_type`: the connector's Glue fallback (`BaseMetadataHandler.doGetTable` -> `GlueMetadataHandler.doGetTable`) was throwing on every request:

```
java.lang.IllegalArgumentException: Multiple entries with same key: segment_5=LarkBaseId=.../LarkBaseTableId=.../LarkBaseFieldId=fldxdVXbHa/LarkBaseFieldName=segment 5/LarkBaseFieldType=Text and segment_5=LarkBaseId=.../LarkBaseTableId=.../LarkBaseFieldId=fldZrayo2s/LarkBaseFieldName=Segment 5/LarkBaseFieldType=Text
```

Verified directly against the Lark Base table: it has two distinct fields, `fldxdVXbHa` ("segment 5") and `fldZrayo2s` ("Segment 5"), differing only by case. `Util.sanitizeGlueRelatedName` lowercases and normalizes column names, so both collapse to the same Glue column name `segment_5`. The crawler wrote both as separate columns with an identical name into the Glue table's `StorageDescriptor`, which Glue itself allows - but when the connector later builds the Arrow schema from those columns, it fails outright (`SchemaBuilder`/`ImmutableMap.Builder` rejects the duplicate key), so the *entire* table's schema resolution breaks, not just the one field.

Fix: in `Util.constructColumns`, detect when a sanitized column name has already been used and disambiguate the later one by appending the Lark field ID (which is always unique), instead of writing two identically-named columns.

## Test plan

- [x] New regression test in `UtilTest` reproducing the exact production field names ("segment 5" / "Segment 5") and field IDs - confirms unique column names are produced
- [x] Full crawler test suite passes (222 tests), checkstyle passes