### PR TITLE
Isolate per-table field-fetch failures in the crawler instead of crashing

### DIFF
--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/BaseLarkBaseCrawlerHandler.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/BaseLarkBaseCrawlerHandler.java
@@ -420,8 +420,19 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
             }
 
             for (ListAllTableResponse.BaseItem tableItem : listTables) {
-                TableInput newTableInput = this.constructNewTables(databaseId, tableItem.getTableId(), tableItem.getName());
-                tableInputs.add(newTableInput);
+                // getTableFields (inside constructNewTables) can fail for reasons unrelated to any
+                // other table - e.g. a field restricted by Advanced Permission at the field level, or
+                // a transient API error - and this table's own field list is a separate Lark API call
+                // per table, not a batch. Isolate the failure to this one table instead of letting it
+                // crash database and table creation for every other table in this (and other) bases.
+                try {
+                    TableInput newTableInput = this.constructNewTables(databaseId, tableItem.getTableId(), tableItem.getName());
+                    tableInputs.add(newTableInput);
+                }
+                catch (Exception e) {
+                    logger.error("Skipping table {} ({}) in base {}: failed to construct table input: {}",
+                            tableItem.getName(), tableItem.getTableId(), databaseId, e.getMessage(), e);
+                }
             }
 
             if (!tableInputs.isEmpty()) {
@@ -720,8 +731,16 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
                         .orElse(null);
 
                 if (tableId != null) {
-                    TableInput newTableInput = this.constructNewTables(databaseId, tableId, tableName);
-                    tablesToCreate.add(newTableInput);
+                    // See the comment in createTablesForNewDatabases: isolate a single table's
+                    // getTableFields failure instead of crashing the whole database update.
+                    try {
+                        TableInput newTableInput = this.constructNewTables(databaseId, tableId, tableName);
+                        tablesToCreate.add(newTableInput);
+                    }
+                    catch (Exception e) {
+                        logger.error("Skipping table {} ({}) in base {}: failed to construct table input: {}",
+                                tableName, tableId, databaseId, e.getMessage(), e);
+                    }
                 }
             }
         }
@@ -755,13 +774,21 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
                         .orElse(null);
 
                 if (existingTable != null) {
-                    TableInput tableInput = this.constructNewTables(databaseId, tableItem.getTableId(), tableName);
-                    boolean hasChanged = doesTableInputChanged(tableInput, existingTable);
-                    logger.info("Table {} has changed: {}", tableName, hasChanged);
+                    // See the comment in createTablesForNewDatabases: isolate a single table's
+                    // getTableFields failure instead of crashing the whole database update.
+                    try {
+                        TableInput tableInput = this.constructNewTables(databaseId, tableItem.getTableId(), tableName);
+                        boolean hasChanged = doesTableInputChanged(tableInput, existingTable);
+                        logger.info("Table {} has changed: {}", tableName, hasChanged);
 
-                    if (hasChanged) {
-                        tablesToUpdate.add(tableInput);
-                        logger.info("Marking table for update: {}", tableName);
+                        if (hasChanged) {
+                            tablesToUpdate.add(tableInput);
+                            logger.info("Marking table for update: {}", tableName);
+                        }
+                    }
+                    catch (Exception e) {
+                        logger.error("Skipping table {} ({}) in base {}: failed to construct table input: {}",
+                                tableName, tableItem.getTableId(), databaseId, e.getMessage(), e);
                     }
                 }
             }

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/LarkBaseCrawlerHandlerTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/LarkBaseCrawlerHandlerTest.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.services.glue.model.Column;
 import software.amazon.awssdk.services.glue.model.Database;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.glue.model.TableInput;
 import software.amazon.awssdk.utils.Pair;
 
 import java.util.Collections;
@@ -255,6 +256,33 @@ public class LarkBaseCrawlerHandlerTest {
         catch (RuntimeException e) {
             assertTrue(e.getMessage().contains("Duplicate table names"));
         }
+    }
+
+    @Test
+    public void testHandleRequest_newDatabaseWithOneTableFailingFieldFetch_othersStillCreated() {
+        // Reproduces a real production risk: getTableFields for one table can fail for reasons
+        // unrelated to any other table - e.g. a field hidden by Advanced Permission at the field
+        // level, or a transient API error - observed as "The role has no permissions" for a whole
+        // table in production logs. Before this fix, constructNewTables had no try/catch around this
+        // call, so one bad table would crash table creation for every other table in the database.
+        LarkDatabaseRecord larkDb = new LarkDatabaseRecord("dbId1", "new_db");
+        ListAllTableResponse.BaseItem goodTable = ListAllTableResponse.BaseItem.builder().tableId("tableId1").name("good_table").build();
+        ListAllTableResponse.BaseItem badTable = ListAllTableResponse.BaseItem.builder().tableId("tableId2").name("bad_table").build();
+
+        when(mockLarkBaseService.getTableRecords("baseDs123", "tableDs456")).thenReturn(Collections.singletonList(larkDb));
+        when(mockGlueCatalogService.getDatabases()).thenReturn(Collections.emptyList());
+        when(mockLarkBaseService.listTables("dbId1")).thenReturn(java.util.Arrays.asList(goodTable, badTable));
+        when(mockLarkBaseService.getTableFields("dbId1", "tableId1")).thenReturn(Collections.emptyList());
+        when(mockLarkBaseService.getTableFields("dbId1", "tableId2")).thenThrow(new RuntimeException("The role has no permissions."));
+
+        String result = handler.handleRequest(payload, mockContext);
+
+        assertEquals("Success", result);
+        org.mockito.ArgumentCaptor<Map<String, List<TableInput>>> captor = org.mockito.ArgumentCaptor.forClass(Map.class);
+        verify(mockGlueCatalogService, times(1)).batchCreateTable(captor.capture());
+        List<TableInput> createdTables = captor.getValue().get("new_db");
+        assertEquals(1, createdTables.size());
+        assertEquals("good_table", createdTables.get(0).name());
     }
 
     @Test


### PR DESCRIPTION
## Summary

Found while investigating a production CloudWatch log: a lookup field's target table had "The role has no permissions" (a table hidden via Lark Base Advanced Permissions), which is already handled gracefully by `getLookupType`'s existing try/catch.

While confirming that fix covers every angle, found a related but unguarded path: `constructNewTables` calls `getTableFields` for the table actively being processed (not a lookup target), with **no error handling at any of its three call sites** (`createTablesForNewDatabases`, `identifyTablesToCreate`, `identifyTablesToUpdate`). A single table's field list can fail for reasons unrelated to any other table - e.g. a field restricted by Advanced Permission at the field level, or any transient API error - and that would crash table creation/update for every other table in every other database in the same crawl run, not just the one problem table.

Fix: wrap each call site so a failing table is logged and skipped, letting the rest of the crawl proceed normally. This lives in the shared `BaseLarkBaseCrawlerHandler`, so it covers both the Lark Base source and Lark Drive source crawler handlers without needing separate changes.

Also verified (no code changes needed, already resilient):
- The lookup-target-table failure path (`getLookupType`) already isolates per-field.
- The connector's `LarkBaseTableResolver`/`ExperimentalMetadataProvider` equivalents already isolate per-table (bulk discovery) or per-query (reactive resolution), and their lookup-chain resolution already isolates per-field via caller-side try/catch.
- The connector's record-fetch pagination (`BaseRecordHandler`) already catches and gracefully stops on any failure instead of crashing the whole query - relevant for potential hidden-row scenarios.

## Test plan

- [x] New regression test reproducing a production-like scenario: one table's `getTableFields` throws (`"The role has no permissions."`), the other table in the same new database still gets created successfully
- [x] Full crawler test suite passes (226 tests), checkstyle clean