### PR TITLE
Isolate per-database Glue/Lark failures and disambiguate colliding table names

### DIFF
--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/BaseLarkBaseCrawlerHandler.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/BaseLarkBaseCrawlerHandler.java
@@ -399,24 +399,27 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
 
             List<TableInput> tableInputs = new ArrayList<>();
 
-            List<ListAllTableResponse.BaseItem> listTables = larkBaseService.listTables(databaseId);
-            LarkDatabaseRecord recordItem = recordsByDatabaseName.get(databaseName);
-            if (recordItem != null) {
-                listTables = filterTablesByAccessControl(listTables, recordItem);
-            }
+            // Listing tables for this database can fail for reasons unrelated to any other database -
+            // e.g. this specific Lark base was deleted or had its permissions changed between
+            // discovery and now. Isolate that failure to this one database instead of letting it crash
+            // table creation for every other new database in the same batch.
+            List<ListAllTableResponse.BaseItem> listTables;
+            try {
+                listTables = larkBaseService.listTables(databaseId);
+                LarkDatabaseRecord recordItem = recordsByDatabaseName.get(databaseName);
+                if (recordItem != null) {
+                    listTables = filterTablesByAccessControl(listTables, recordItem);
+                }
 
-            // Same collision risk as processTablesForDatabase: two distinct Lark tables in this
-            // (brand-new) base can collide after name sanitization (e.g. "Report A" and "report a"
-            // both -> "report_a"). Unlike processTablesForDatabase (which collapses collisions into a
-            // Set before ever reaching Glue, silently keeping only one table), this method builds a
-            // plain list, so without this check Glue's own createTable call would eventually reject
-            // the second one with a confusing AlreadyExistsException - after already partially
-            // creating other tables for this database. Fail fast with a clear message instead.
-            List<String> newTableNamesForValidation = listTables.stream()
-                    .map(item -> item.getName().toLowerCase())
-                    .collect(Collectors.toList());
-            if (new HashSet<>(newTableNamesForValidation).size() != newTableNamesForValidation.size()) {
-                throw new RuntimeException("Duplicate table names found (after sanitization) in Lark base " + databaseId);
+                // Two distinct Lark tables in this (brand-new) base can collide after name
+                // sanitization (e.g. "Report A" and "report a" both -> "report_a"). Disambiguate with
+                // the Lark table ID, same fix as colliding column names in Util.constructColumns,
+                // rather than silently keeping only one or erroring out this whole database.
+                listTables = Util.disambiguateDuplicateTableNames(listTables);
+            }
+            catch (Exception e) {
+                logger.error("Skipping database {} ({}): failed to list tables: {}", databaseName, databaseId, e.getMessage(), e);
+                continue;
             }
 
             for (ListAllTableResponse.BaseItem tableItem : listTables) {
@@ -536,7 +539,18 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
                         logger.info("No changes needed for database: {}", database.name());
                     }
 
-                    UpdateDatabaseProcessResult result = processTablesForDatabase(database, recordItem);
+                    // processTablesForDatabase calls out to both Glue (getTables) and Lark (listTables)
+                    // for this one database, plus the duplicate-name fail-fast check. Isolate a failure
+                    // there to this one database instead of letting it crash the update/create/delete
+                    // diffing for every other database being processed in this same crawl run.
+                    UpdateDatabaseProcessResult result;
+                    try {
+                        result = processTablesForDatabase(database, recordItem);
+                    }
+                    catch (Exception e) {
+                        logger.error("Skipping database {}: failed to process tables: {}", database.name(), e.getMessage(), e);
+                        continue;
+                    }
 
                     if (result.tablesToDelete() != null && !result.tablesToDelete().isEmpty()) {
                         tablesToDelete.put(database.name(), result.tablesToDelete());
@@ -616,14 +630,10 @@ abstract class BaseLarkBaseCrawlerHandler implements RequestHandler<Object, Stri
         // Two distinct Lark tables in the same base can collide after name sanitization (e.g.
         // "Report A" and "report a" both -> "report_a"). The create/update/delete diffing below is
         // entirely keyed by this lowercased name, so a collision would silently make one of the two
-        // tables invisible to the crawler (never created in Glue) instead of erroring. Fail loudly
-        // here, consistent with how database name collisions are already handled.
-        List<String> larkTableNamesForValidation = larkTables.stream()
-                .map(item -> item.getName().toLowerCase())
-                .collect(Collectors.toList());
-        if (new HashSet<>(larkTableNamesForValidation).size() != larkTableNamesForValidation.size()) {
-            throw new RuntimeException("Duplicate table names found (after sanitization) in Lark base " + recordItem.id());
-        }
+        // tables invisible to the crawler (never created in Glue) instead of erroring. Disambiguate
+        // with the Lark table ID, same fix as colliding column names in Util.constructColumns, rather
+        // than silently dropping one table or erroring out this whole database.
+        larkTables = Util.disambiguateDuplicateTableNames(larkTables);
 
         Map<String, String> larkTableNameMap = new HashMap<>();
         Map<String, String> glueTableNameMap = new HashMap<>();

--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/service/GlueCatalogService.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/service/GlueCatalogService.java
@@ -19,7 +19,10 @@
  */
 package com.amazonaws.glue.lark.base.crawler.service;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.AlreadyExistsException;
 import software.amazon.awssdk.services.glue.model.BatchDeleteTableRequest;
 import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
@@ -51,6 +54,8 @@ import static java.util.Objects.requireNonNull;
  */
 public class GlueCatalogService
 {
+    private static final Logger logger = LoggerFactory.getLogger(GlueCatalogService.class);
+
     private final GlueClient glueClient;
     private final String catalogId;
 
@@ -94,10 +99,17 @@ public class GlueCatalogService
     public void batchDeleteDatabase(List<String> databaseNames)
     {
         for (String databaseName : databaseNames) {
-            glueClient.deleteDatabase(DeleteDatabaseRequest.builder()
-                    .name(databaseName)
-                    .catalogId(catalogId)
-                    .build());
+            // Isolate one database's delete failure (e.g. a concurrent invocation already deleted it)
+            // instead of aborting deletion of the rest of the batch.
+            try {
+                glueClient.deleteDatabase(DeleteDatabaseRequest.builder()
+                        .name(databaseName)
+                        .catalogId(catalogId)
+                        .build());
+            }
+            catch (Exception e) {
+                logger.error("Failed to delete database {}: {}", databaseName, e.getMessage(), e);
+            }
         }
     }
 
@@ -131,7 +143,22 @@ public class GlueCatalogService
                     .catalogId(catalogId)
                     .build();
 
-            glueClient.createDatabase(request);
+            // Observed in production: a concurrent/overlapping crawler invocation can create the same
+            // database first, so this call throws AlreadyExistsException - which is harmless (the
+            // database is there either way) but, left uncaught, aborted this whole loop before it ever
+            // reached the remaining databases in the batch. Since the caller (createGlueDatabases) goes
+            // on to create tables for every database in this batch regardless of which of these calls
+            // actually succeeded, isolating one database's failure here is enough to let table creation
+            // proceed normally for the rest instead of getting stuck retrying forever with zero tables.
+            try {
+                glueClient.createDatabase(request);
+            }
+            catch (AlreadyExistsException e) {
+                logger.info("Database {} already exists, skipping creation.", databaseNameWithLocationUri.getKey());
+            }
+            catch (Exception e) {
+                logger.error("Failed to create database {}: {}", databaseNameWithLocationUri.getKey(), e.getMessage(), e);
+            }
         }
     }
 
@@ -160,11 +187,17 @@ public class GlueCatalogService
                             )
                     ).build();
 
-            glueClient.updateDatabase(UpdateDatabaseRequest.builder()
-                    .name(databaseNameWithLocationUri.getKey())
-                    .databaseInput(databaseInput)
-                    .catalogId(catalogId)
-                    .build());
+            // Isolate one database's update failure instead of aborting the rest of the batch.
+            try {
+                glueClient.updateDatabase(UpdateDatabaseRequest.builder()
+                        .name(databaseNameWithLocationUri.getKey())
+                        .databaseInput(databaseInput)
+                        .catalogId(catalogId)
+                        .build());
+            }
+            catch (Exception e) {
+                logger.error("Failed to update database {}: {}", databaseNameWithLocationUri.getKey(), e.getMessage(), e);
+            }
         }
     }
 
@@ -203,14 +236,20 @@ public class GlueCatalogService
     public void batchDeleteTable(Map<String, List<Table>> databaseNameAndTables)
     {
         for (Map.Entry<String, List<Table>> dbEntry : databaseNameAndTables.entrySet()) {
-            glueClient.batchDeleteTable(
-                    BatchDeleteTableRequest.builder()
-                            .databaseName(dbEntry.getKey())
-                            .tablesToDelete(dbEntry.getValue().stream()
-                                    .map(Table::name)
-                                    .collect(Collectors.toList()))
-                            .catalogId(catalogId)
-                            .build());
+            // Isolate one database's delete-table batch failure instead of aborting the rest.
+            try {
+                glueClient.batchDeleteTable(
+                        BatchDeleteTableRequest.builder()
+                                .databaseName(dbEntry.getKey())
+                                .tablesToDelete(dbEntry.getValue().stream()
+                                        .map(Table::name)
+                                        .collect(Collectors.toList()))
+                                .catalogId(catalogId)
+                                .build());
+            }
+            catch (Exception e) {
+                logger.error("Failed to delete tables in database {}: {}", dbEntry.getKey(), e.getMessage(), e);
+            }
         }
     }
 
@@ -224,12 +263,23 @@ public class GlueCatalogService
     {
         for (Map.Entry<String, List<TableInput>> databaseNameAndTableInput : databaseNameAndTableInputs.entrySet()) {
             for (TableInput tableInput : databaseNameAndTableInput.getValue()) {
-                glueClient.createTable(
-                        CreateTableRequest.builder()
-                                .databaseName(databaseNameAndTableInput.getKey())
-                                .tableInput(tableInput)
-                                .catalogId(catalogId)
-                                .build());
+                // Isolate one table's create failure (e.g. AlreadyExistsException from a concurrent
+                // invocation, same race condition as batchCreateDatabase above) instead of aborting
+                // creation of every other table across every other database in this same batch.
+                try {
+                    glueClient.createTable(
+                            CreateTableRequest.builder()
+                                    .databaseName(databaseNameAndTableInput.getKey())
+                                    .tableInput(tableInput)
+                                    .catalogId(catalogId)
+                                    .build());
+                }
+                catch (AlreadyExistsException e) {
+                    logger.info("Table {}.{} already exists, skipping creation.", databaseNameAndTableInput.getKey(), tableInput.name());
+                }
+                catch (Exception e) {
+                    logger.error("Failed to create table {}.{}: {}", databaseNameAndTableInput.getKey(), tableInput.name(), e.getMessage(), e);
+                }
             }
         }
     }
@@ -244,12 +294,19 @@ public class GlueCatalogService
     {
         for (Map.Entry<String, List<TableInput>> databaseNameAndTableInput : databaseNameAndTableInputs.entrySet()) {
             for (TableInput tableInput : databaseNameAndTableInput.getValue()) {
-                glueClient.updateTable(
-                        UpdateTableRequest.builder()
-                                .databaseName(databaseNameAndTableInput.getKey())
-                                .tableInput(tableInput)
-                                .catalogId(catalogId)
-                                .build());
+                // Isolate one table's update failure instead of aborting every other table update
+                // across every other database in this same batch.
+                try {
+                    glueClient.updateTable(
+                            UpdateTableRequest.builder()
+                                    .databaseName(databaseNameAndTableInput.getKey())
+                                    .tableInput(tableInput)
+                                    .catalogId(catalogId)
+                                    .build());
+                }
+                catch (Exception e) {
+                    logger.error("Failed to update table {}.{}: {}", databaseNameAndTableInput.getKey(), tableInput.name(), e.getMessage(), e);
+                }
             }
         }
     }

--- a/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/util/Util.java
+++ b/glue-lark-base-crawler/src/main/java/com/amazonaws/glue/lark/base/crawler/util/Util.java
@@ -21,6 +21,7 @@ package com.amazonaws.glue.lark.base.crawler.util;
 
 import com.amazonaws.glue.lark.base.crawler.model.ColumnParameters;
 import com.amazonaws.glue.lark.base.crawler.model.TableInputParameters;
+import com.amazonaws.glue.lark.base.crawler.model.response.ListAllTableResponse;
 import software.amazon.awssdk.services.glue.model.Column;
 import software.amazon.awssdk.services.glue.model.StorageDescriptor;
 import software.amazon.awssdk.services.glue.model.TableInput;
@@ -322,5 +323,33 @@ public final class Util
     public static String sanitizeGlueRelatedName(String tableName)
     {
         return tableName.toLowerCase().replaceAll("[^a-zA-Z0-9$]", "_");
+    }
+
+    /**
+     * Disambiguate Lark tables whose names collide after sanitization (e.g. "Report A" and "report a"
+     * both -> "report_a"). Same collision class and fix as {@link #constructColumns}: since the Lark
+     * table ID is unique, a colliding table's name is suffixed with it rather than silently dropping
+     * or erroring on one of the two tables.
+     *
+     * @param tables The Lark tables
+     * @return The tables with any name collisions disambiguated
+     */
+    public static List<ListAllTableResponse.BaseItem> disambiguateDuplicateTableNames(List<ListAllTableResponse.BaseItem> tables)
+    {
+        Set<String> seenTableNames = new HashSet<>();
+        List<ListAllTableResponse.BaseItem> disambiguated = new ArrayList<>();
+        for (ListAllTableResponse.BaseItem table : tables) {
+            String tableName = table.getName();
+            if (!seenTableNames.add(tableName)) {
+                tableName = tableName + "_" + sanitizeGlueRelatedName(table.getTableId());
+                seenTableNames.add(tableName);
+            }
+            disambiguated.add(ListAllTableResponse.BaseItem.builder()
+                    .tableId(table.getTableId())
+                    .revision(table.getRevision())
+                    .name(tableName)
+                    .build());
+        }
+        return disambiguated;
     }
 }

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/LarkBaseCrawlerHandlerTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/LarkBaseCrawlerHandlerTest.java
@@ -139,11 +139,13 @@ public class LarkBaseCrawlerHandlerTest {
     }
 
     @Test
-    public void handleRequest_duplicateSanitizedTableNamesInSameBase_throws() {
+    public void handleRequest_duplicateSanitizedTableNamesInSameBase_disambiguatedByTableId() {
         // Reproduces a real risk: two distinct Lark tables in the same base (e.g. "Report A" and
         // "report a") both sanitize to the same Glue table name. The create/update/delete diffing in
-        // processTablesForDatabase is entirely keyed by this name, so without a check, one of the two
-        // tables would silently never get created in Glue instead of erroring.
+        // processTablesForDatabase is entirely keyed by this name, so without disambiguation, one of
+        // the two tables would silently never get created in Glue. Same fix as colliding column names
+        // (Util.constructColumns): suffix the colliding name with the table's unique Lark table ID
+        // instead of erroring or dropping one of them.
         LarkDatabaseRecord larkDb = new LarkDatabaseRecord("dbId1", "db_name");
         Database glueDb = Database.builder().name("db_name")
                 .locationUri("lark-base-flag/CrawlingMethod=LarkBase/DataSource=baseDs123:tableDs456/Base=dbId1").build();
@@ -154,14 +156,18 @@ public class LarkBaseCrawlerHandlerTest {
         when(mockGlueCatalogService.getDatabases()).thenReturn(Collections.singletonList(glueDb));
         when(mockGlueCatalogService.getTables("db_name")).thenReturn(Collections.emptyList());
         when(mockLarkBaseService.listTables("dbId1")).thenReturn(java.util.Arrays.asList(larkTable1, larkTable2));
+        when(mockLarkBaseService.getTableFields(anyString(), anyString())).thenReturn(Collections.emptyList());
 
-        try {
-            handler.handleRequest(payload, mockContext);
-            fail("Expected RuntimeException for duplicate table names");
-        }
-        catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Duplicate table names"));
-        }
+        String result = handler.handleRequest(payload, mockContext);
+
+        assertEquals("Success", result);
+        org.mockito.ArgumentCaptor<Map<String, List<TableInput>>> captor = org.mockito.ArgumentCaptor.forClass(Map.class);
+        verify(mockGlueCatalogService, times(1)).batchCreateTable(captor.capture());
+        List<TableInput> createdTables = captor.getValue().get("db_name");
+        assertEquals(2, createdTables.size());
+        List<String> createdNames = createdTables.stream().map(TableInput::name).collect(java.util.stream.Collectors.toList());
+        assertTrue(createdNames.contains("report_a"));
+        assertTrue(createdNames.contains("report_a_tableid2"));
     }
 
 
@@ -237,10 +243,10 @@ public class LarkBaseCrawlerHandlerTest {
     }
 
     @Test
-    public void testHandleRequest_newDatabaseWithDuplicateSanitizedTableNames_throws() {
-        // Same collision risk as handleRequest_duplicateSanitizedTableNamesInSameBase_throws, but for
-        // a brand-new database (createTablesForNewDatabases), which has its own separate listTables
-        // call and duplicate-name check from the "update an existing database" path.
+    public void testHandleRequest_newDatabaseWithDuplicateSanitizedTableNames_disambiguatedByTableId() {
+        // Same collision risk as handleRequest_duplicateSanitizedTableNamesInSameBase_disambiguatedByTableId,
+        // but for a brand-new database (createTablesForNewDatabases), which has its own separate
+        // listTables call and disambiguation from the "update an existing database" path.
         LarkDatabaseRecord larkDb = new LarkDatabaseRecord("dbId1", "new_db");
         ListAllTableResponse.BaseItem larkTable1 = ListAllTableResponse.BaseItem.builder().tableId("tableId1").name("report a").build();
         ListAllTableResponse.BaseItem larkTable2 = ListAllTableResponse.BaseItem.builder().tableId("tableId2").name("Report A").build();
@@ -248,14 +254,18 @@ public class LarkBaseCrawlerHandlerTest {
         when(mockLarkBaseService.getTableRecords("baseDs123", "tableDs456")).thenReturn(Collections.singletonList(larkDb));
         when(mockGlueCatalogService.getDatabases()).thenReturn(Collections.emptyList());
         when(mockLarkBaseService.listTables("dbId1")).thenReturn(java.util.Arrays.asList(larkTable1, larkTable2));
+        when(mockLarkBaseService.getTableFields(anyString(), anyString())).thenReturn(Collections.emptyList());
 
-        try {
-            handler.handleRequest(payload, mockContext);
-            fail("Expected RuntimeException for duplicate table names");
-        }
-        catch (RuntimeException e) {
-            assertTrue(e.getMessage().contains("Duplicate table names"));
-        }
+        String result = handler.handleRequest(payload, mockContext);
+
+        assertEquals("Success", result);
+        org.mockito.ArgumentCaptor<Map<String, List<TableInput>>> captor = org.mockito.ArgumentCaptor.forClass(Map.class);
+        verify(mockGlueCatalogService, times(1)).batchCreateTable(captor.capture());
+        List<TableInput> createdTables = captor.getValue().get("new_db");
+        assertEquals(2, createdTables.size());
+        List<String> createdNames = createdTables.stream().map(TableInput::name).collect(java.util.stream.Collectors.toList());
+        assertTrue(createdNames.contains("report_a"));
+        assertTrue(createdNames.contains("report_a_tableid2"));
     }
 
     @Test

--- a/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/service/GlueCatalogServiceTest.java
+++ b/glue-lark-base-crawler/src/test/java/com/amazonaws/glue/lark/base/crawler/service/GlueCatalogServiceTest.java
@@ -73,6 +73,28 @@ class GlueCatalogServiceTest {
     }
 
     @Test
+    void testBatchCreateDatabase_oneAlreadyExists_othersStillCreated() {
+        // Reproduces a real production incident: a concurrent/overlapping crawler invocation created
+        // one of these databases first, so Glue throws AlreadyExistsException for it. Before this fix,
+        // that exception aborted this whole loop uncaught, so a database earlier in iteration order
+        // (e.g. "mec_reporting_activities") got created but every database after the failing one in
+        // this batch never did - and since createGlueDatabases only calls createTablesForNewDatabases
+        // after this method returns, none of them ever got their tables created either, indefinitely,
+        // since every subsequent crawl run hit the exact same race again.
+        Map<String, String> databaseNamesWithLocationUri = Map.of(
+                "already_exists_db", "s3://test-location-1/",
+                "new_db", "s3://test-location-2/"
+        );
+        when(glueClient.createDatabase(argThat((CreateDatabaseRequest r) ->
+                r.databaseInput().name().equals("already_exists_db"))))
+                .thenThrow(AlreadyExistsException.builder().message("Database already exists.").build());
+
+        glueCatalogService.batchCreateDatabase(databaseNamesWithLocationUri);
+
+        verify(glueClient, times(2)).createDatabase(any(CreateDatabaseRequest.class));
+    }
+
+    @Test
     void testBatchUpdateDatabase() {
         Map<String, String> databaseNamesWithLocationUri = Map.of(
                 "testDatabase1", "s3://test-location-1/",


### PR DESCRIPTION
Continues the per-item failure isolation from the previous commit, one level up the call stack and at the Glue API layer itself.

GlueCatalogService's batch create/update/delete calls for databases and tables were unguarded, so one item's failure (e.g. a concurrent crawler invocation racing to create the same database, observed in production as AlreadyExistsException) aborted the whole loop before it reached the rest of the batch. Each call site now isolates its own failure, and AlreadyExistsException is treated as a harmless no-op instead of an error.

createTablesForNewDatabases and updateGlueDatabases loop over multiple databases per invocation, but a Lark/Glue failure for one database (e.g. listTables()) wasn't isolated and aborted processing for every other database in the same crawl run. Both are now isolated per-database, consistent with the per-table isolation already in place.

Also replaced the duplicate-sanitized-table-name check, which threw and aborted the whole database, with disambiguation by Lark table ID - same fix already used for colliding column names in Util.constructColumns. Two Lark tables colliding after sanitization (e.g. "Report A" and "report a") no longer error out or silently drop one of them.