### PR TITLE
Cap emitted rows at expectedRowCountForSplit instead of whatever the last page carried

### DIFF
--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseRecordHandler.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/BaseRecordHandler.java
@@ -463,6 +463,7 @@ public class BaseRecordHandler extends RecordHandler
             private String currentPageToken = null;
             private boolean hasMorePages = true;
             private int currentFetchDataCount = 0;
+            private int emittedCount = 0;
             private final String finalFilterExpression = buildFinalFilter();
             private final String finalSortExpression = isParallelSplit && envVarService.isActivateParallelSplit() ? "" : originalSortExpression;
 
@@ -556,6 +557,14 @@ public class BaseRecordHandler extends RecordHandler
             @Override
             public boolean hasNext()
             {
+                // expectedRowCountForSplit only gates whether fetchNextPage() asks Lark for another
+                // page (checked before/after each fetch) - it never trims the page that pushes the
+                // running total over the limit. A single over-fetched page can carry up to
+                // pageSizeForApi extra records past the target, so the emitted-count cap here is what
+                // actually enforces the boundary regardless of how much this split over-fetched.
+                if (expectedRowCountForSplit > 0 && emittedCount >= expectedRowCountForSplit) {
+                    return false;
+                }
                 if (currentPageIterator != null && currentPageIterator.hasNext()) {
                     return true;
                 }
@@ -572,6 +581,7 @@ public class BaseRecordHandler extends RecordHandler
                     throw new NoSuchElementException("No more records available for this split");
                 }
                 SearchRecordsResponse.RecordItem item = currentPageIterator.next();
+                emittedCount++;
                 Map<String, Object> result = item.getFields() instanceof HashMap ?
                         item.getFields() : new HashMap<>(item.getFields());
                 result.put(RESERVED_RECORD_ID, item.getRecordId());

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/BaseRecordHandlerTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/BaseRecordHandlerTest.java
@@ -658,6 +658,11 @@ public class BaseRecordHandlerTest {
 
     @Test
     public void testGetIteratorExceedsExpectedRowCount() throws Exception {
+        // A single page can carry more records than expectedRowCountForSplit asks for (e.g. the split
+        // planner estimated 5 rows for this split, but one page fetch returns 10 because the API
+        // doesn't slice mid-page). The iterator must stop emitting exactly at expectedRowCountForSplit
+        // rather than yielding every record it happened to fetch - otherwise a split can emit more
+        // rows than Athena's split-planning phase accounted for.
         List<SearchRecordsResponse.RecordItem> items = new ArrayList<>();
         for (int i = 0; i < 10; i++) {
             items.add(SearchRecordsResponse.RecordItem.builder()
@@ -696,7 +701,7 @@ public class BaseRecordHandlerTest {
             iterator.next();
             count++;
         }
-        assertEquals(10, count);
+        assertEquals(5, count);
     }
 
     @Test
@@ -1252,15 +1257,15 @@ public class BaseRecordHandlerTest {
                 Collections.emptyMap()
         );
 
-        // Fetch all available in first page (10 items)
+        // First page carries more items (10) than expectedRowCountForSplit asks for (5).
         int count = 0;
         while (iterator.hasNext() && count < 15) {
             iterator.next();
             count++;
         }
 
-        // Should have gotten all 10 items even though expected was 5
-        assertEquals(10, count);
+        // Must stop at the expected count, not at however many the first page happened to carry.
+        assertEquals(5, count);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- `expectedRowCountForSplit` was only gating whether to fetch another page, not how many rows actually get emitted - a split whose target fell mid-page would fetch a full extra page and write every record in it, overshooting by up to `pageSizeForApi` rows.
- Traced from a real query: a table with 606 records returned 1000 rows in Athena. Split planning correctly computed `expected_row_count=606`, but the fetch loop pulled two full 500-record pages before noticing it had already gone past 606, by which point all 1000 were buffered and written.
- `hasNext()` now stops emitting once the running emitted count hits `expectedRowCountForSplit`, regardless of how much extra ended up in the page that crossed the line.
- Two existing tests (`testGetIteratorExceedsExpectedRowCount`, `testGetIteratorStopsAtExpectedRowCountWithDebugLogging`) had actually asserted the old overshoot behavior as correct (asserting 10 rows back when the target was 5) - updated both to assert the row cap is respected.

## Test plan
- [x] `mvn test -pl athena-lark-base -am -Dtest=BaseRecordHandlerTest` - all pass
- [x] Full `athena-lark-base` module test suite - all pass
- [ ] Manual verification against the table that originally showed the 606 vs 1000 discrepancy