### PR TITLE
Fix nullability test bugs found during regression sweep

### DIFF
--- a/integration-tests/python/tests/regression/test_comprehensive_nullability.py
+++ b/integration-tests/python/tests/regression/test_comprehensive_nullability.py
@@ -229,32 +229,38 @@ class ComprehensiveNullabilityTest(BaseRegressionTest):
         return self.run_field_test("USER IS NOT NULL", "field_user", "IS NOT NULL", expected_to_fail=True)
 
     def test_user_field_is_null(self):
-        """Test USER field with IS NULL."""
-        return self.run_field_test("USER IS NULL", "field_user", "IS NULL", expected_to_fail=True)
+        """Test USER field with IS NULL.
+
+        Unlike IS NOT NULL, this doesn't need MarkerFactory to materialize a comparable
+        value for the List-typed column - same reason MULTI_SELECT/GROUP_CHAT/ATTACHMENT's
+        IS NULL succeeds below. All of these share the same Arrow LIST MinorType (see
+        LarkBaseTypeUtils), so there's no mechanical reason USER would behave differently.
+        """
+        return self.run_field_test("USER IS NULL", "field_user", "IS NULL", expected_to_fail=False)
 
     def test_lookup_field_is_not_null(self):
         """Test LOOKUP field with IS NOT NULL."""
         return self.run_field_test("LOOKUP IS NOT NULL", "field_lookup", "IS NOT NULL", expected_to_fail=True)
 
     def test_lookup_field_is_null(self):
-        """Test LOOKUP field with IS NULL."""
-        return self.run_field_test("LOOKUP IS NULL", "field_lookup", "IS NULL", expected_to_fail=True)
+        """Test LOOKUP field with IS NULL. See test_user_field_is_null for why this succeeds."""
+        return self.run_field_test("LOOKUP IS NULL", "field_lookup", "IS NULL", expected_to_fail=False)
 
     def test_created_user_field_is_not_null(self):
         """Test CREATED_USER field with IS NOT NULL."""
         return self.run_field_test("CREATED_USER IS NOT NULL", "field_created_user", "IS NOT NULL", expected_to_fail=True)
 
     def test_created_user_field_is_null(self):
-        """Test CREATED_USER field with IS NULL."""
-        return self.run_field_test("CREATED_USER IS NULL", "field_created_user", "IS NULL", expected_to_fail=True)
+        """Test CREATED_USER field with IS NULL. See test_user_field_is_null for why this succeeds."""
+        return self.run_field_test("CREATED_USER IS NULL", "field_created_user", "IS NULL", expected_to_fail=False)
 
     def test_modified_user_field_is_not_null(self):
         """Test MODIFIED_USER field with IS NOT NULL."""
         return self.run_field_test("MODIFIED_USER IS NOT NULL", "field_modified_user", "IS NOT NULL", expected_to_fail=True)
 
     def test_modified_user_field_is_null(self):
-        """Test MODIFIED_USER field with IS NULL."""
-        return self.run_field_test("MODIFIED_USER IS NULL", "field_modified_user", "IS NULL", expected_to_fail=True)
+        """Test MODIFIED_USER field with IS NULL. See test_user_field_is_null for why this succeeds."""
+        return self.run_field_test("MODIFIED_USER IS NULL", "field_modified_user", "IS NULL", expected_to_fail=False)
 
     # Array type tests
     def test_multi_select_field_is_not_null(self):

--- a/integration-tests/python/tests/regression/test_json_filters.py
+++ b/integration-tests/python/tests/regression/test_json_filters.py
@@ -24,6 +24,8 @@ class JSONFilterTester(BaseRegressionTest):
     def __init__(self, verbose: bool = False):
         super().__init__(verbose)
         self.lark_api_base = get_lark_api_base_url()
+        self.lark_base_token = os.getenv("LARK_BASE_APP_TOKEN", "test_base_token")
+        self.lark_table_id = os.getenv("LARK_BASE_TABLE_ID", "test_table_id")
         self.access_token = None
 
     def setup(self):

--- a/integration-tests/python/tests/regression/test_search_api_filters.py
+++ b/integration-tests/python/tests/regression/test_search_api_filters.py
@@ -24,6 +24,8 @@ class SearchAPIFilterTester(BaseRegressionTest):
     def __init__(self, verbose: bool = False):
         super().__init__(verbose)
         self.lark_api_base = get_lark_api_base_url()
+        self.lark_base_token = os.getenv("LARK_BASE_APP_TOKEN", "test_base_token")
+        self.lark_table_id = os.getenv("LARK_BASE_TABLE_ID", "test_table_id")
         self.access_token = None
 
     def setup(self):


### PR DESCRIPTION
## Summary
- `test_json_filters.py` and `test_search_api_filters.py` were both missing `lark_base_token`/`lark_table_id` initialization in `__init__`, causing an `AttributeError` on every run
- `test_comprehensive_nullability.py` had 4 tests (USER/LOOKUP/CREATED_USER/MODIFIED_USER `IS NULL`) asserting `expected_to_fail=True`, but these fields are mechanically identical Arrow LIST columns to MULTI_SELECT/GROUP_CHAT/ATTACHMENT, which already expected success — fixed the expectations to match observed, consistent behavior

## Test plan
- [x] Ran `test_json_filters.py` directly in AWS mode: 8/8 pass
- [x] Ran `test_comprehensive_nullability.py` directly in AWS mode: 37/46 pass (up from 33/46), remaining 9 failures are genuine platform limitations (List `IS NOT NULL` / Struct predicates), tracked separately