### PR TITLE
Fix test harness bugs blocking experimental/direct-provider/crawler test coverage

### DIFF
--- a/integration-tests/python/config.py
+++ b/integration-tests/python/config.py
@@ -13,6 +13,9 @@ Usage:
 import os
 from enum import Enum
 from typing import Dict, Any
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), '../../.env'))
 
 
 class TestEnvironment(Enum):

--- a/integration-tests/python/run_all_tests.py
+++ b/integration-tests/python/run_all_tests.py
@@ -36,31 +36,31 @@ ALL_TESTS = {
     # Migrated tests (in integration-tests module)
     "glue_crawler": {
         "name": "Glue Crawler Test",
-        "script": "integration-tests/python/tests/regression/test_glue_crawler.py",
+        "script": "integration-tests/python/tests/crawlers/test_glue_crawler.py",
         "migrated": True,
         "modes": ["mock", "hybrid", "aws"]
     },
     "glue_regression": {
         "name": "Glue Provider Regression Test",
-        "script": "integration-tests/python/tests/regression/test_glue_regression.py",
+        "script": "integration-tests/python/tests/regression/test_comprehensive_queries.py",
         "migrated": True,
         "modes": ["mock", "aws"]
     },
     "lark_base_source_regression": {
         "name": "Lark Base Source Regression Test",
-        "script": "integration-tests/python/tests/regression/test_lark_base_source.py",
+        "script": "integration-tests/python/tests/providers/test_lark_base_source.py",
         "migrated": True,
         "modes": ["mock", "aws"]
     },
     "lark_drive_source_regression": {
         "name": "Lark Drive Source Regression Test",
-        "script": "integration-tests/python/tests/regression/test_lark_drive_source_regression.py",
+        "script": "integration-tests/python/tests/providers/test_lark_drive_source.py",
         "migrated": True,
         "modes": ["mock", "aws"]
     },
     "experimental_provider_regression": {
         "name": "Experimental Provider Regression Test",
-        "script": "integration-tests/python/tests/regression/test_experimental_provider.py",
+        "script": "integration-tests/python/tests/providers/test_experimental_provider.py",
         "migrated": True,
         "modes": ["mock", "aws"]
     },

--- a/integration-tests/python/tests/providers/test_experimental_provider.py
+++ b/integration-tests/python/tests/providers/test_experimental_provider.py
@@ -39,7 +39,7 @@ class ExperimentalProviderTest(BaseRegressionTest):
         # Experimental provider uses base_id.table_id format
         # Format: database = base_id, table = table_id
         self.test_base_id = os.getenv("TEST_BASE_ID", "EEMGbnS87a2W1IsaJKhjds3fpwe")
-        self.test_table_id = os.getenv("TEST_TABLE_ID", "tblCGeqbqp03ivAY")
+        self.test_table_id = os.getenv("TEST_TABLE_ID", "tblehzVRm83N1vOX")
 
         # Experimental uses base_id as database and table_id as table name
         self.test_database = self.test_base_id


### PR DESCRIPTION
## Summary
- `config.py` never called `load_dotenv()`, so every test importing its constants (`CRAWLER_FUNCTION_NAME`, `AWS_REGION`, etc.) silently used stale hardcoded defaults instead of the real values in `.env` - this alone made `test_glue_crawler.py` try to invoke a nonexistent Lambda (`test-lark-crawler`) in the wrong region (`us-east-1`)
- `run_all_tests.py` registered 5 tests (`glue_crawler`, `glue_regression`, `lark_base_source_regression`, `lark_drive_source_regression`, `experimental_provider_regression`) under wrong or nonexistent script paths - since a missing script path is treated as `[SKIP]` rather than a failure, none of these have actually been executing via that runner. Fixed all 5 paths, and pointed `glue_regression` at `test_comprehensive_queries.py`, which was itself sitting completely unregistered
- `test_experimental_provider.py` defaulted its test table ID to the Lark base's control/mapping table instead of the actual data table, causing spurious `COLUMN_NOT_FOUND` failures for columns that table was never supposed to have

## Test plan
Ran all 5 previously-broken tests directly against AWS after the fixes:
- [x] `test_glue_crawler.py`: 45/45 pass
- [x] `test_lark_base_source.py` (direct/no-Glue metadata provider): 6/6 pass
- [x] `test_lark_drive_source.py`: 4/4 pass
- [x] `test_experimental_provider.py`: 5/5 pass (was 2/5 before the table-ID fix)
- [x] `test_comprehensive_queries.py`: 17/20 pass - remaining 3 are the already-documented List/Struct platform limitation (2) plus an Athena engine-level `OFFSET` syntax rejection unrelated to this connector (1)