### PR TITLE
Fix ClassCastException on chained LOOKUP fields with a single linked record

### DIFF
--- a/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractor.java
+++ b/athena-lark-base/src/main/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractor.java
@@ -503,6 +503,27 @@ public class RegistererExtractor
         });
     }
 
+    /**
+     * A chained LOOKUP (e.g. Lookup&lt;Lookup&lt;MultiSelect&gt;&gt;) produces an Arrow schema nested one
+     * List level deeper per chain hop (List&lt;List&lt;Utf8&gt;&gt;, List&lt;List&lt;Struct&gt;&gt;, ...), but
+     * Lark's API collapses a single-linked-record LOOKUP down to a bare scalar (String/Map) instead of
+     * wrapping it in the full chain of Lists. Wrapping such a scalar exactly once (as this method's callers
+     * do for the outermost level) leaves any inner List levels holding a raw scalar where a List was
+     * expected, which is what threw the "String/LinkedHashMap cannot be cast to List" writer exceptions.
+     * This walks the field's child-List chain below the outermost level and wraps once per level found,
+     * so the final single-element structure matches the schema's actual nesting depth.
+     */
+    private static Object wrapScalarToMatchNestedListDepth(Object scalarValue, Field listField)
+    {
+        Object wrapped = scalarValue;
+        Field current = listField;
+        while (!current.getChildren().isEmpty() && current.getChildren().get(0).getType() instanceof ArrowType.List) {
+            wrapped = List.of(wrapped);
+            current = current.getChildren().get(0);
+        }
+        return wrapped;
+    }
+
     private void registerListFieldWriterFactory(GeneratedRowWriter.RowWriterBuilder rowWriterBuilder, Field field)
     {
         LarkBaseFieldResolver resolver = new LarkBaseFieldResolver();
@@ -532,14 +553,14 @@ public class RegistererExtractor
                         // Wrap it in a List to match the expected array schema
                         logger.debug("FieldWriterFactory for List field '{}': Got Map instead of List (likely LINK field). Wrapping in List.",
                                 fieldName);
-                        listValue = List.of(unwrappedValue);
+                        listValue = List.of(wrapScalarToMatchNestedListDepth(unwrappedValue, field));
                     }
                     else if (unwrappedValue instanceof String) {
                         // LOOKUP fields may return as String instead of List
                         // Wrap it in a List to match the expected array schema
                         logger.debug("FieldWriterFactory for List field '{}': Got String instead of List (likely LOOKUP field). Wrapping in List.",
                                 fieldName);
-                        listValue = List.of(unwrappedValue);
+                        listValue = List.of(wrapScalarToMatchNestedListDepth(unwrappedValue, field));
                     }
                     else {
                         logger.error("FieldWriterFactory for List field '{}': Expected List, Map, or String, got {}. Writing null.",

--- a/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractorTest.java
+++ b/athena-lark-base/src/test/java/com/amazonaws/athena/connectors/lark/base/translator/RegistererExtractorTest.java
@@ -1331,6 +1331,86 @@ public class RegistererExtractorTest {
         }
     }
 
+    @Test
+    public void testListFieldWriterFactory_withStringValue_nestedListSchema() throws Exception {
+        // A chained LOOKUP (e.g. Lookup<Lookup<MultiSelect>>) produces a doubly-nested Arrow schema:
+        // List<List<Utf8>>. Lark collapses a single-linked-record LOOKUP to a bare String though, so the
+        // writer must wrap it twice (once per List level), not once, to match the schema.
+        ArgumentCaptor<FieldWriterFactory> factoryCaptor = ArgumentCaptor.forClass(FieldWriterFactory.class);
+        Field innerListField = new Field("item", FieldType.nullable(new ArrowType.List()),
+                Collections.singletonList(new Field("item", FieldType.nullable(new ArrowType.Utf8()), null)));
+        Field outerListField = new Field("nested_list_field", FieldType.nullable(new ArrowType.List()),
+                Collections.singletonList(innerListField));
+        Schema schema = new Schema(Collections.singletonList(outerListField));
+
+        registererExtractor.registerExtractorsForSchema(mockRowWriterBuilder, schema);
+        verify(mockRowWriterBuilder).withFieldWriterFactory(eq("nested_list_field"), factoryCaptor.capture());
+
+        FieldWriterFactory factory = factoryCaptor.getValue();
+        FieldVector mockVector = mock(FieldVector.class);
+        Extractor mockExtractor = mock(Extractor.class);
+
+        try (MockedStatic<BlockUtils> blockUtilsMock = mockStatic(BlockUtils.class)) {
+            FieldWriter writer = factory.create(mockVector, mockExtractor, null);
+
+            Map<String, Object> context = new HashMap<>();
+            context.put("nested_list_field", "single string value");
+
+            boolean result = writer.write(context, 0);
+
+            assertTrue(result);
+            // Expect [["single string value"]] - wrapped twice to match List<List<Utf8>>
+            blockUtilsMock.verify(() -> BlockUtils.setComplexValue(eq(mockVector), eq(0), any(LarkBaseFieldResolver.class), argThat(arg -> {
+                if (!(arg instanceof List) || ((List<?>) arg).size() != 1) {
+                    return false;
+                }
+                Object inner = ((List<?>) arg).get(0);
+                return inner instanceof List && ((List<?>) inner).size() == 1
+                        && "single string value".equals(((List<?>) inner).get(0));
+            })));
+        }
+    }
+
+    @Test
+    public void testListFieldWriterFactory_withMapValue_nestedListSchema() throws Exception {
+        // A chained LOOKUP<User> (e.g. Lookup<Lookup<User>>) produces List<List<Struct>>. Lark collapses a
+        // single-linked-record LOOKUP to a bare Map (LinkedHashMap) though, so the writer must wrap it twice.
+        ArgumentCaptor<FieldWriterFactory> factoryCaptor = ArgumentCaptor.forClass(FieldWriterFactory.class);
+        Field innerListField = new Field("item", FieldType.nullable(new ArrowType.List()),
+                Collections.singletonList(new Field("item", FieldType.nullable(new ArrowType.Utf8()), null)));
+        Field outerListField = new Field("nested_map_field", FieldType.nullable(new ArrowType.List()),
+                Collections.singletonList(innerListField));
+        Schema schema = new Schema(Collections.singletonList(outerListField));
+
+        registererExtractor.registerExtractorsForSchema(mockRowWriterBuilder, schema);
+        verify(mockRowWriterBuilder).withFieldWriterFactory(eq("nested_map_field"), factoryCaptor.capture());
+
+        FieldWriterFactory factory = factoryCaptor.getValue();
+        FieldVector mockVector = mock(FieldVector.class);
+        Extractor mockExtractor = mock(Extractor.class);
+
+        try (MockedStatic<BlockUtils> blockUtilsMock = mockStatic(BlockUtils.class)) {
+            FieldWriter writer = factory.create(mockVector, mockExtractor, null);
+
+            Map<String, Object> mapValue = new HashMap<>();
+            mapValue.put("id", "ou_12345");
+            Map<String, Object> context = new HashMap<>();
+            context.put("nested_map_field", mapValue);
+
+            boolean result = writer.write(context, 0);
+
+            assertTrue(result);
+            // Expect [[mapValue]] - wrapped twice to match List<List<Struct>>
+            blockUtilsMock.verify(() -> BlockUtils.setComplexValue(eq(mockVector), eq(0), any(LarkBaseFieldResolver.class), argThat(arg -> {
+                if (!(arg instanceof List) || ((List<?>) arg).size() != 1) {
+                    return false;
+                }
+                Object inner = ((List<?>) arg).get(0);
+                return inner instanceof List && ((List<?>) inner).size() == 1 && mapValue.equals(((List<?>) inner).get(0));
+            })));
+        }
+    }
+
     // Tests for Struct field writer factory
     @Test
     public void testStructFieldWriterFactory_withNullValue() throws Exception {


### PR DESCRIPTION
## Summary
- A chained LOOKUP (e.g. `Lookup<Lookup<MultiSelect>>`, or any LOOKUP targeting an inherently plural type like USER/MULTI_SELECT/GROUP_CHAT/ATTACHMENT) produces an Arrow schema nested one `List` level deeper per hop - `List<List<Utf8>>`, `List<List<Struct>>`, etc.
- Lark's API collapses such a field down to a bare scalar (String/Map) instead of the full List chain whenever there's exactly one linked record. `RegistererExtractor`'s list field writer only ever wrapped that scalar once, regardless of how deep the actual schema was nested - leaving an inner `List` level holding a raw String/Map where a `List` was expected, throwing `class java.lang.String cannot be cast to class java.util.List` (or `LinkedHashMap` for Map-shaped fields).
- Traced from a real production query (`LIMIT 10` silently returning 0 rows) via CloudWatch logs, which pointed at this writer. Confirmed live against the affected Lark base that two more fields in the same table (`BP_Name`, `Product`) share the identical doubly-nested schema and are equally exposed - the fix is schema-driven (walks the field's actual Arrow nesting depth) rather than field-name-specific, so it covers them too without extra changes.

## Fix
`registerListFieldWriterFactory` now wraps a collapsed scalar once per `List` level actually present in the field's Arrow schema (via a new `wrapScalarToMatchNestedListDepth` helper) instead of always wrapping exactly once.

## Test plan
- [x] Added `testListFieldWriterFactory_withStringValue_nestedListSchema` and `testListFieldWriterFactory_withMapValue_nestedListSchema` covering the doubly-nested case
- [x] `RegistererExtractorTest`: 66/66 pass (was 64, all pre-existing single-level-list tests unaffected)
- [x] Full `athena-lark-base` module: 599/599 pass